### PR TITLE
fix audio playback in the Steam webview, fixes #3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -117,11 +117,13 @@ parts:
       - usr/bin/yad*
       - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/alsa-lib
       - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libasound*
+      - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libasyncns*
       - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libdnsfile*
       - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libFLAC*
       - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libjack*
       - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libpulse*
       - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libsamplerate*
+      - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libsndfile*
       - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libspeex*
       - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvorbis*
       - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio


### PR DESCRIPTION
Added two additional libraries to the alsa-mixin
- libsndfile
- libasyncns (which is marked as unsatisfied dependency for the alsa-mixin during snap build)

```
Priming alsa-mixin 
+ snapcraftctl prime
This part is missing libraries that cannot be satisfied with any available stage-packages known to snapcraft:
- libasyncns.so.0
- libogg.so.0

```

Tested and verified audio in the store was back after including those two.
libasyncns is not an audio related lib but since it's related to the alsa-mixin I've put them all together.
