### PR TITLE
set VK_ICD_FILENAMES to allow NVidia Vulkan to work

### DIFF
--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -168,6 +168,9 @@ if [ -e "/var/lib/snapd/lib/gl/vdpau/libvdpau_nvidia.so" ]; then
   unset LIBVA_DRIVERS_PATH
 fi
 
+# Export Vulkan ICD filename paths
+export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:$SNAP/usr/share/vulkan/icd.d/intel_icd.x86_64.json"
+
 # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
 # /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH
 # Without that OpenGL using apps do not work with the nVidia drivers.


### PR DESCRIPTION
At present when launching Linux native games using the snap, Nvidia graphics aren't detected and defaults to software rendering using llvmpipe. This change allows Vulkan to be used with Nvidia GPUs by adding the path to the `nvidia_icd.json` file to the `VK_ICD_FILENAME` environment variable, which previously wasn't set by the snap.