### PR TITLE
Disable wayland support, fixes #22

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -209,6 +209,7 @@ apps:
       #LIBGL_DEBUG: verbose
       TMPDIR: $XDG_RUNTIME_DIR
       ALWAYS_USE_PULSEAUDIO: 1
+      DISABLE_WAYLAND: 1
 
     plugs:
       - shared-memory


### PR DESCRIPTION
Some games attempt to load the Qt platform plugin for wayland, we probably don't want to use wayland for steam yet anyway.