### PR TITLE
Include locale data in snap to support non-ASCII input

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -202,6 +202,7 @@ parts:
       - pciutils
       - vulkan-tools # For testing
       - lsof
+      - locales-all
     override-build: |
       snapcraftctl build
       # Set the snap version from the .deb package version


### PR DESCRIPTION
Attempts to fix #5 by including `locales-all` in `stage-packages`. Seems to allow me to type non ASCII characters like Russian into the client now.