### PR TITLE
Add GameMode

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -204,6 +204,7 @@ parts:
       - mesa-utils # For testing/debugging
       - lsof
       - locales-all
+      - gamemode
     override-build: |
       snapcraftctl build
       # Set the snap version from the .deb package version

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -167,12 +167,25 @@ parts:
       fi
       apt update
 
+  gamemode:
+    source: https://github.com/ashuntu/gamemode.git
+    source-branch: 'add-snap-support'
+    plugin: meson
+    organize:
+      snap/steam/current/usr: usr
+    meson-parameters:
+      - --prefix=/usr
+    build-packages:
+      - libsystemd-dev
+      - pkg-config
+      - libdbus-1-dev
+
   steam-devices:
     plugin: dump
     source: https://github.com/ValveSoftware/steam-devices.git
 
   steam:
-    after: [ enable-i386 ]
+    after: [ enable-i386, gamemode ]
     plugin: nil
     #source: http://repo.steampowered.com/steam/archive/precise/steam_latest.deb
     build-packages:
@@ -204,7 +217,6 @@ parts:
       - mesa-utils # For testing/debugging
       - lsof
       - locales-all
-      - gamemode
     override-build: |
       snapcraftctl build
       # Set the snap version from the .deb package version


### PR DESCRIPTION
Adds [GameMode](https://github.com/FeralInteractive/gamemode) via [my fork](https://github.com/ashuntu/gamemode/tree/add-snap-support), including small changes to allow Snaps to be considered sandboxed. This should hit [xdg-desktop-portal](https://github.com/ashuntu/xdg-desktop-portal/tree/snap-support) if the user is running a build that handles Snaps.

## Use GameMode

To use GameMode, right-click on a game in your Library, click 'Properties...', and add the following to 'Launch Options':
```shell
gamemoderun %command%
```

If you have a compatible portal build running, your game should then be listed when running `gamemodelist` (outside of the Snap).