### PR TITLE
Prime gamemoderun and libgamemode.so files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -179,6 +179,9 @@ parts:
       - libsystemd-dev
       - pkg-config
       - libdbus-1-dev
+    prime:
+      - usr/bin/gamemoderun
+      - usr/lib/*/libgamemode*.so.*
 
   steam-devices:
     plugin: dump


### PR DESCRIPTION
Added prime directive to the GameMode part to include `usr/bin/gamemoderun` and `usr/lib/*/libgamemode*.so.*`.

Issue #42 