### PR TITLE
DT-709: fix linking error

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -79,6 +79,16 @@ layout:
     bind-file: $SNAP/usr/lib/i386-linux-gnu/libvulkan_radeon.so
   /usr/lib/x86_64-linux-gnu/libvulkan_radeon.so:
     bind-file: $SNAP/usr/lib/x86_64-linux-gnu/libvulkan_radeon.so
+  /usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0:
+    bind-file: $SNAP/usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
+  /usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0:
+    symlink: $SNAP/usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
+  /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0:
+    bind-file: $SNAP/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
+  /usr/lib/x86_64-linux-gnu/libxcb.so:
+    symlink: $SNAP/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
+  /usr/lib/x86_64-linux-gnu/libxcb.so.1:
+    symlink: $SNAP/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
   /etc/ld.so.cache:
     bind-file: $SNAP_DATA/etc/ld.so.cache
 
@@ -200,6 +210,8 @@ parts:
       - libappindicator3-1
       - libvkd3d1:i386
       - libvkd3d1:amd64
+      - libxcb-dri3-0:amd64
+      - libxcb-dri3-0:i386
       - zlib1g:i386
       - zlib1g:amd64
       - mesa-va-drivers:i386


### PR DESCRIPTION
During startup, an error is displayed about a missing symbol when linking the Radeon and SWRast drivers:

libGL error: MESA-LOADER: failed to open radeonsi: /snap/steam/x8/usr/lib/x86_64-linux-gnu/dri/radeonsi_dri.so: undefined symbol: xcb_dri3_buffers_from_pixmap_strides (search paths /snap/steam/x8/usr/lib/i386-linux-gnu/dri:/snap/steam/x8/usr/lib/x86_64-linux-gnu/dri, suffix _dri) libGL error: failed to load driver: radeonsi
libGL error: MESA-LOADER: failed to open swrast: /snap/steam/x8/usr/lib/x86_64-linux-gnu/dri/swrast_dri.so: undefined symbol: xcb_dri3_buffers_from_pixmap_strides (search paths /snap/steam/x8/usr/lib/i386-linux-gnu/dri:/snap/steam/x8/usr/lib/x86_64-linux-gnu/dri, suffix _dri) libGL error: failed to load driver: swrast

The problem is because steam includes, by default, an old version of the libxcb library to ensure compatibility with old linux versions, but, according to the developers, if they detect a newer version in the installed operating system, they copy that version.

More details in the issue:
	https://github.com/ValveSoftware/steam-runtime/issues/539

In the case of the Snap, that library isn't available in the root folders, so Steam is unable to find it.

To fix this, this MR binds and links the right library version in the root filesystem.