### PR TITLE
steamreport: Add --verbose and --force options, fail gracefully on error

### DIFF
--- a/src/steamreport
+++ b/src/steamreport
@@ -151,8 +151,7 @@ if (not args.force):
     if (not os.environ.get("SNAP")):
         sys.exit(
             "This script must be ran from inside a Snap environment.\n" +
-            "Run `snap run steam.report`, or\n" +
-            "run `snap run --shell steam`, then `steamreport`."
+            "Run `snap run steam.report`."
         )
 
     if (os.system("snapctl is-connected system-observe")):

--- a/src/steamreport
+++ b/src/steamreport
@@ -18,11 +18,12 @@ def dict_to_string(d, n = 0):
     """Convert a dict to yaml-like string."""
     s = ""
     for key in d:
-        s += f"{'    ' * n}{key}: "
+        line = f"{'    ' * n}{key}: "
         if (type(d[key]) is dict):
-            s += f"\n{dict_to_string(d[key], n + 1)}"
+            line += f"\n{dict_to_string(d[key], n + 1)}"
         else:
-            s += f"{d[key]}\n"
+            line += f"{' ' * (24 - len(line))}{d[key]}\n"
+        s += line
     return s
 
 def gather_data():
@@ -62,6 +63,16 @@ def gather_data():
         "steam_revision": os.environ.get("SNAP_REVISION"),
         "snapd_revision": os.popen("readlink /snap/snapd/current").read().strip()
     }
+
+    # lspci
+    lspci = defaultdict(default)
+    for line in os.popen("lspci | grep VGA").read().split("\n"):
+        line = line.strip()
+        if (not line): continue
+        key, val = line.split(" ", 1)
+        lspci[key.strip()] = val.strip().removeprefix("VGA compatible controller: ")
+
+    data["lspci"] = dict(lspci)
 
     # glxinfo -B
     glxinfo = defaultdict(default)

--- a/src/steamreport
+++ b/src/steamreport
@@ -150,8 +150,9 @@ args = parser.parse_args()
 if (not args.force):
     if (not os.environ.get("SNAP")):
         sys.exit(
-            "Script must be ran from inside a Snap environment.\n" +
-            "Run `snap run --shell steam`, then `steamreport`."
+            "This script must be ran from inside a Snap environment.\n" +
+            "Run `snap run steam.report`, or\n" +
+            "run `snap run --shell steam`, then `steamreport`."
         )
 
     if (os.system("snapctl is-connected system-observe")):

--- a/src/steamreport
+++ b/src/steamreport
@@ -45,6 +45,7 @@ def gather_data():
 
                     key, val = line.split("=", 1)
                     os_release[key] = val
+            break
         except FileNotFoundError:
             continue
 

--- a/src/steamreport
+++ b/src/steamreport
@@ -3,14 +3,16 @@
 import os
 import sys
 import webbrowser
-import json
 import argparse
-import json
+from collections import defaultdict
 
 DISCUSSION_URL = "https://github.com/canonical/steam-snap/discussions/new?category=game-reports"
 WIKI_URL = "https://github.com/canonical/steam-snap/wiki/Troubleshooting#submitting-a-game-report"
 
 BODY_SUFFIX = "<!--Copy error logs from Steam/the game itself below-->"
+
+def default():
+    return "ERROR"
 
 def dict_to_string(d, n = 0):
     """Convert a dict to yaml-like string."""
@@ -28,7 +30,7 @@ def gather_data():
     data = {}
 
     # /etc/os-release
-    os_release = {}
+    os_release = defaultdict(default)
     with open("/var/lib/snapd/hostfs/etc/os-release", "r") as reader:
         for line in reader:
             line = line.strip()
@@ -37,10 +39,13 @@ def gather_data():
             key, val = line.split("=", 1)
             os_release[key] = val
 
-    data["os_release"] = {
-        "name": os_release["NAME"],
-        "version": os_release["VERSION"]
-    }
+    if (args.verbose):
+        data["os_release"] = dict(os_release)
+    else:
+        data["os_release"] = {
+            "name": os_release["NAME"],
+            "version": os_release["VERSION"]
+        }
 
     # snap info
     data["snap_info"] = {
@@ -49,36 +54,42 @@ def gather_data():
     }
 
     # glxinfo -B
-    glxinfo = {}
+    glxinfo = defaultdict(default)
     for line in os.popen("glxinfo -B").read().split("\n"):
         line = line.strip()
         if (not line): continue
         key, val = line.split(":", 1)
         glxinfo[key.strip()] = val.strip()
 
-    data["glxinfo"] = {
-        "gpu": glxinfo["OpenGL renderer string"],
-        "gpu_version": glxinfo["OpenGL core profile version string"]
-    }
+    if (args.verbose):
+        data["glxinfo"] = dict(glxinfo)
+    else:
+        data["glxinfo"] = {
+            "gpu": glxinfo["OpenGL renderer string"],
+            "gpu_version": glxinfo["OpenGL core profile version string"]
+        }
 
     # lscpu
-    lscpu = {}
+    lscpu = defaultdict(default)
     for line in os.popen("lscpu").read().split("\n"):
         line = line.strip()
         if (not line): continue
         key, val = line.split(":", 1)
         lscpu[key.strip()] = val.strip()
 
-    data["lscpu"] = {
-        "model_name": lscpu["Model name"]
-    }
+    if (args.verbose):
+        data["lscpu"] = dict(lscpu)
+    else:
+        data["lscpu"] = {
+            "model_name": lscpu["Model name"]
+        }
 
     return data
 
 def submit_data(data):
     """Open web-browser and fill in system information."""
     url = DISCUSSION_URL
-    url += f"&title=Report: {args.game.capitalize()}"
+    url += f"&title=Report: {args.title.capitalize()}"
     url += f"&body=```\n{dict_to_string(data)}```\n".replace("\n", "%0A")
     url += BODY_SUFFIX
     print("Opening web browser...")
@@ -89,9 +100,9 @@ parser = argparse.ArgumentParser(
     description=f"Visit {WIKI_URL} for more information."
 )
 parser.add_argument(
-    "game",
-    help="Name of the game to report",
-    default="GAME_NAME",
+    "title",
+    help="Title of the game to report, or title of issue category.",
+    default="TITLE",
     nargs="?"
 )
 parser.add_argument(
@@ -100,26 +111,39 @@ parser.add_argument(
     const=True,
     action="store_const"
 )
+parser.add_argument(
+    "--verbose", "-v",
+    help="Include entire output from data collection.",
+    const=True,
+    action="store_const"
+)
+parser.add_argument(
+    "--force", "-f",
+    help="Skip environment checks and run anyway.",
+    const=True,
+    action="store_const"
+)
 args = parser.parse_args()
 
 # Test environment
-if (not os.environ.get("SNAP")):
-    sys.exit(
-        "Script must be ran from inside a Snap environment.\n" +
-        "Run `snap run --shell steam`, then `steamreport`."
-    )
+if (not args.force):
+    if (not os.environ.get("SNAP")):
+        sys.exit(
+            "Script must be ran from inside a Snap environment.\n" +
+            "Run `snap run --shell steam`, then `steamreport`."
+        )
 
-if (os.system("snapctl is-connected system-observe")):
-    sys.exit(
-        "This script relies on the system-observe Snap plug.\n" +
-        "Outside of the snap, run `snap connect steam:system-observe`."
-    )
+    if (os.system("snapctl is-connected system-observe")):
+        sys.exit(
+            "This script relies on the system-observe Snap plug.\n" +
+            "Outside of the snap, run `snap connect steam:system-observe`."
+        )
 
-if (os.system("snapctl is-connected hardware-observe")):
-    sys.exit(
-        "This script relies on the hardware-observe Snap plug.\n" +
-        "Outside of the snap, run `snap connect steam:hardware-observe`."
-    )
+    if (os.system("snapctl is-connected hardware-observe")):
+        sys.exit(
+            "This script relies on the hardware-observe Snap plug.\n" +
+            "Outside of the snap, run `snap connect steam:hardware-observe`."
+        )
 
 # Gather and submit data
 data = gather_data()

--- a/src/steamreport
+++ b/src/steamreport
@@ -31,13 +31,22 @@ def gather_data():
 
     # /etc/os-release
     os_release = defaultdict(default)
-    with open("/var/lib/snapd/hostfs/etc/os-release", "r") as reader:
-        for line in reader:
-            line = line.strip()
-            if (not line): continue
+    os_release_lookup = [
+        "/var/lib/snapd/hostfs/etc/os-release", # system-observe host os-release
+        "/etc/os-release",                      # usual system os-release
+    ]
 
-            key, val = line.split("=", 1)
-            os_release[key] = val
+    for path in os_release_lookup:
+        try:
+            with open(path, "r") as reader:
+                for line in reader:
+                    line = line.strip()
+                    if (not line): continue
+
+                    key, val = line.split("=", 1)
+                    os_release[key] = val
+        except FileNotFoundError:
+            continue
 
     if (args.verbose):
         data["os_release"] = dict(os_release)
@@ -49,7 +58,7 @@ def gather_data():
 
     # snap info
     data["snap_info"] = {
-        "steam_revision": os.environ["SNAP_REVISION"],
+        "steam_revision": os.environ.get("SNAP_REVISION"),
         "snapd_revision": os.popen("readlink /snap/snapd/current").read().strip()
     }
 

--- a/src/steamreport
+++ b/src/steamreport
@@ -110,7 +110,7 @@ def gather_data():
 def submit_data(data):
     """Open web-browser and fill in system information."""
     url = DISCUSSION_URL
-    url += f"&title=Report: {args.title.capitalize()}"
+    url += f"&title=Report: {args.title.title()}"
     url += f"&body=```\n{dict_to_string(data)}```\n".replace("\n", "%0A")
     url += BODY_SUFFIX
     print("Opening web browser...")


### PR DESCRIPTION
Adds --verbose and --force options to steam.report

steam.report will fail gracefully when encountering key errors for the likes of `lscpu`, `glxinfo`, etc.

Adds fallback os-release path
Adds lspci output for VGA devices
Output string is vertically aligned 