### PR TITLE
Silence bad 32-bit lints

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,16 @@ compression: lzo
 assumes:
   - snapd2.55.4
 
+lint:
+  # Snapcraft's `ldd` lint can't handle 32-bit things,
+  # So just make it quiet and also make builds a surprising amount faster
+  ignore:
+    - library:
+        - lib/i386-linux-gnu/**
+        - usr/lib/i386-linux-gnu/**
+        - lib32/**
+        - usr/lib32/**
+
 package-repositories:
   - type: apt
     url: http://repo.steampowered.com/steam/


### PR DESCRIPTION
This uses the new Snapcraft feature to silence lints on 32-bit libraries.

Previously you would always get a litany of warnings that it cannot determine
dependencies for any i386 libraries, this makes it not bother to check them.

This does not affect the final build in any way - it is purely a development
QOL change.
