### PR TITLE
Fix fonts in Big Picture (and elsewhere)

### DIFF
--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -275,50 +275,8 @@ fi
 # Keep an array of data dirs, for looping through them
 IFS=':' read -r -a data_dirs_array <<< "$XDG_DATA_DIRS"
 
-# Font Config and themes
-export FONTCONFIG_PATH="$SNAP_DESKTOP_RUNTIME/etc/fonts"
-export FONTCONFIG_FILE="$SNAP_DESKTOP_RUNTIME/etc/fonts/fonts.conf"
-
-function make_user_fontconfig {
-  echo "<fontconfig>"
-  if [ -d "$REALHOME/.local/share/fonts" ]; then
-    echo "  <dir>$REALHOME/.local/share/fonts</dir>"
-  fi
-  if [ -d "$REALHOME/.fonts" ]; then
-    echo "  <dir>$REALHOME/.fonts</dir>"
-  fi
-  for ((i = 0; i < ${#data_dirs_array[@]}; i++)); do
-    if [ -d "${data_dirs_array[$i]}/fonts" ]; then
-      echo "  <dir>${data_dirs_array[$i]}/fonts</dir>"
-    fi
-  done
-  # fix font render for modified fonts, that discussed on Snapcraft Forum:
-  # https://forum.snapcraft.io/t/snap-package-cannot-read-fonts-conf/16657
-  echo '  <include ignore_missing="yes">/etc/fonts/conf.d</include>'
-  echo '  <include ignore_missing="yes">conf.d</include>'
-  # Add the Steam font configs
-  echo "  <include ignore_missing=\"yes\">$SNAP_USER_COMMON/.local/share/Steam/bin/panorama/etc/fonts/fonts.conf</include>"
-  echo "  <include ignore_missing=\"yes\">$SNAP_USER_COMMON/.local/share/Steam/bin/panorama/etc/fonts/fonts.d</include>"
-  echo "  <include ignore_missing=\"yes\">$SNAP_USER_COMMON/fontconfig/.config/fontconfig/fonts.conf</include>"
-  # And the steam fonts themselves
-  echo "  <dir>$SNAP_USER_COMMON/.local/share/Steam/clientui/fonts</dir>"
-  echo "  <dir>$SNAP_USER_COMMON/.local/share/Steam/tenfoot/resources/fonts</dir>"
-  echo "  <dir>$SNAP_USER_COMMON/.local/share/Steam/resource/fonts</dir>"
-  # We need to include a user-writable cachedir first to support
-  # caching of per-user fonts.
-  echo '  <cachedir prefix="xdg">fontconfig</cachedir>'
-  echo "  <cachedir>$SNAP_COMMON/fontconfig</cachedir>"
-  echo "</fontconfig>"
-}
-
 if [ "$needs_update" = true ]; then
-  rm -rf "$XDG_DATA_HOME"/{fontconfig,fonts,fonts-*,themes,.themes}
-
-  # This fontconfig fragment is installed in a location that is
-  # included by the system fontconfig configuration: namely the
-  # etc/fonts/conf.d/50-user.conf file.
-  ensure_dir_exists "$XDG_CONFIG_HOME/fontconfig"
-  async_exec make_user_fontconfig > "$XDG_CONFIG_HOME/fontconfig/fonts.conf"
+  rm -rf "$XDG_DATA_HOME"/{themes,.themes}
 fi
 
 ##############################

--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -296,6 +296,14 @@ function make_user_fontconfig {
   # https://forum.snapcraft.io/t/snap-package-cannot-read-fonts-conf/16657
   echo '  <include ignore_missing="yes">/etc/fonts/conf.d</include>'
   echo '  <include ignore_missing="yes">conf.d</include>'
+  # Add the Steam font configs
+  echo "  <include ignore_missing=\"yes\">$SNAP_USER_COMMON/.local/share/Steam/bin/panorama/etc/fonts/fonts.conf</include>"
+  echo "  <include ignore_missing=\"yes\">$SNAP_USER_COMMON/.local/share/Steam/bin/panorama/etc/fonts/fonts.d</include>"
+  echo "  <include ignore_missing=\"yes\">$SNAP_USER_COMMON/fontconfig/.config/fontconfig/fonts.conf</include>"
+  # And the steam fonts themselves
+  echo "  <dir>$SNAP_USER_COMMON/.local/share/Steam/clientui/fonts</dir>"
+  echo "  <dir>$SNAP_USER_COMMON/.local/share/Steam/tenfoot/resources/fonts</dir>"
+  echo "  <dir>$SNAP_USER_COMMON/.local/share/Steam/resource/fonts</dir>"
   # We need to include a user-writable cachedir first to support
   # caching of per-user fonts.
   echo '  <cachedir prefix="xdg">fontconfig</cachedir>'


### PR DESCRIPTION
This fixes Big Picture mode (and a few other fonts that were using system fallback fonts instead of vendored ones) by removing the fontcfg handling from the `desktop-launch` script entirely. At first I tried adding all font configurations *not* somewhere in `steamapps/common` (which includes things such as Steam VR and various versions of the Steam Linux Runtime), just because it's impossible to do that programmatically because most have versioned directories. However, this caused Steam to break even worse. The commit is in there so we can look at it in the future without having to redo the work I did and tweak it, and thus should probably not be squashed out.

fixes #5 

![image](https://user-images.githubusercontent.com/93421308/205187667-4e0fe1c9-3982-4d2e-8b65-ab2d26a488b5.png)
