### PR TITLE
Add usbutils for controller support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -256,6 +256,7 @@ parts:
       - mesa-utils # For testing/debugging
       - lsof
       - locales-all
+      - usbutils # Allows finding controllers etc
     override-build: |
       craftctl default
       # Set the snap version from the .deb package version


### PR DESCRIPTION
This finally lets my PS5 controller work in games! This should really just be merged ASAP IMO, it more or less completely fixes controller support (provided you have the udev rules installed outside the Snap).
