### PR TITLE
Revert "Add uinput plug for virtual controller"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -318,7 +318,6 @@ apps:
       - fuse-support
       - steam-support
       - removable-media
-      - uinput
       - upower-observe
   report:
     command: bin/steamreport


### PR DESCRIPTION
This reverts commit d48d370626c6fb7e54cd820ed059214446281cbf.

Temporarily revert `uinput` plug addition because we need permission for it to publish.