### PR TITLE
Vulkan layout fixes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -215,6 +215,13 @@ parts:
       - vulkan-tools
       - mesa-utils
 
+  tests:
+    plugin: dump
+    source: tests
+    override-build: |
+      mkdir -p $CRAFT_PART_INSTALL/tests
+      cp -rp * $CRAFT_PART_INSTALL/tests/
+
   steam-devices:
     plugin: dump
     source: https://github.com/ValveSoftware/steam-devices.git
@@ -363,6 +370,13 @@ apps:
   glxgears:
     command-chain: [bin/desktop-launch]
     command: usr/bin/glxgears
+    plugs:
+      - opengl
+      - x11
+      - desktop
+  test:
+    command-chain: [bin/desktop-launch]
+    command: tests/run.sh
     plugs:
       - opengl
       - x11

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -362,7 +362,7 @@ apps:
       - desktop
   glxgears:
     command-chain: [bin/desktop-launch]
-    command: usr/bin/glxinfo
+    command: usr/bin/glxgears
     plugs:
       - opengl
       - x11

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,7 +63,7 @@ layout:
   /usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0:
     symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
   /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0:
-    bind-file: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
+    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
   /usr/lib/x86_64-linux-gnu/libxcb.so:
     symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
   /usr/lib/x86_64-linux-gnu/libxcb.so.1:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,31 +45,31 @@ layout:
   /usr/lib/i386-linux-gnu:
     bind: $SNAP/usr/lib/i386-linux-gnu
   /usr/lib/x86_64-linux-gnu/dri:
-    bind: $SNAP/usr/lib/x86_64-linux-gnu/dri
+    bind: $SNAP/graphics/usr/lib/x86_64-linux-gnu/dri
   /usr/share/glvnd/egl_vendor.d:
-    bind: $SNAP/usr/share/glvnd/egl_vendor.d
+    bind: $SNAP/graphics/usr/share/glvnd/egl_vendor.d
   /usr/lib/x86_64-linux-gnu/alsa-lib:
     bind: $SNAP/usr/lib/x86_64-linux-gnu/alsa-lib
   /usr/share/alsa:
     bind: $SNAP/usr/share/alsa
   /usr/share/vulkan:
-    bind: $SNAP/usr/share/vulkan
+    bind: $SNAP/graphics/usr/share/vulkan
   /usr/lib/x86_64-linux-gnu/libvulkan_intel.so:
-    bind-file: $SNAP/usr/lib/x86_64-linux-gnu/libvulkan_intel.so
+    bind-file: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_intel.so
   /usr/lib/x86_64-linux-gnu/libvulkan_lvp.so:
-    bind-file: $SNAP/usr/lib/x86_64-linux-gnu/libvulkan_lvp.so
+    bind-file: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_lvp.so
   /usr/lib/x86_64-linux-gnu/libvulkan_radeon.so:
-    bind-file: $SNAP/usr/lib/x86_64-linux-gnu/libvulkan_radeon.so
+    bind-file: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_radeon.so
   /usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0:
-    bind-file: $SNAP/usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
+    bind-file: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
   /usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0:
-    symlink: $SNAP/usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
+    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
   /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0:
-    bind-file: $SNAP/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
+    bind-file: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
   /usr/lib/x86_64-linux-gnu/libxcb.so:
-    symlink: $SNAP/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
+    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
   /usr/lib/x86_64-linux-gnu/libxcb.so.1:
-    symlink: $SNAP/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
+    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
   /etc/ld.so.cache:
     bind-file: $SNAP_DATA/etc/ld.so.cache
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -340,3 +340,27 @@ apps:
       - opengl
       - x11
       - desktop
+  vulkaninfo:
+    command: usr/bin/vulkaninfo
+    plugs:
+      - opengl
+      - x11
+      - desktop
+  vkcube:
+    command: usr/bin/vkcube
+    plugs:
+      - opengl
+      - x11
+      - desktop
+  glxinfo:
+    command: usr/bin/glxinfo
+    plugs:
+      - opengl
+      - x11
+      - desktop
+  glxgears:
+    command: usr/bin/glxinfo
+    plugs:
+      - opengl
+      - x11
+      - desktop

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,16 +52,14 @@ layout:
     bind: $SNAP/usr/lib/x86_64-linux-gnu/alsa-lib
   /usr/share/alsa:
     bind: $SNAP/usr/share/alsa
-  /usr/share/vulkan:
-    bind: $SNAP/graphics/usr/share/vulkan
   /usr/lib/x86_64-linux-gnu/libvulkan_intel.so:
-    bind-file: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_intel.so
+    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_intel.so
   /usr/lib/x86_64-linux-gnu/libvulkan_lvp.so:
-    bind-file: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_lvp.so
+    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_lvp.so
   /usr/lib/x86_64-linux-gnu/libvulkan_radeon.so:
-    bind-file: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_radeon.so
+    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_radeon.so
   /usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0:
-    bind-file: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
+    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
   /usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0:
     symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
   /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -331,6 +331,7 @@ apps:
       - removable-media
       - upower-observe
   report:
+    command-chain: [bin/desktop-launch]
     command: bin/steamreport
     plugs:
       - system-observe
@@ -339,24 +340,28 @@ apps:
       - x11
       - desktop
   vulkaninfo:
+    command-chain: [bin/desktop-launch]
     command: usr/bin/vulkaninfo
     plugs:
       - opengl
       - x11
       - desktop
   vkcube:
+    command-chain: [bin/desktop-launch]
     command: usr/bin/vkcube
     plugs:
       - opengl
       - x11
       - desktop
   glxinfo:
+    command-chain: [bin/desktop-launch]
     command: usr/bin/glxinfo
     plugs:
       - opengl
       - x11
       - desktop
   glxgears:
+    command-chain: [bin/desktop-launch]
     command: usr/bin/glxinfo
     plugs:
       - opengl

--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -188,7 +188,7 @@ if [ -e "/var/lib/snapd/lib/gl/vdpau/libvdpau_nvidia.so" ]; then
 fi
 
 # Export Vulkan ICD filename paths
-export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:$SNAP/usr/share/vulkan/icd.d/intel_icd.x86_64.json"
+export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/graphics/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:$SNAP/graphics/usr/share/vulkan/icd.d/intel_icd.x86_64.json"
 
 # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
 # /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH

--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -6,6 +6,13 @@
 # shellcheck disable=SC2034
 START=$(date +%s.%N)
 
+if ! snapctl is-connected "gaming-mesa"; then
+  echo "ERROR: not connected to the gaming-mesa content interface."
+  echo "To connect:"
+  echo "sudo snap connect steam:gaming-mesa gaming-graphics-core22"
+  exit 1
+fi
+
 # ensure_dir_exists calls `mkdir -p` if the given path is not a directory.
 # This speeds up execution time by avoiding unnecessary calls to mkdir.
 #

--- a/tests/glx
+++ b/tests/glx
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+glxinfo | grep "direct rendering: Yes" 2>&1> /dev/null
+exit $?

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+test glx 2>&1> /dev/null && echo "GLX passed" || echo "GLX failed"
+test vulkan 2>&1> /dev/null && echo "Vulkan passed" || echo "Vulkan failed"

--- a/tests/vulkan
+++ b/tests/vulkan
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+vulkaninfo --json|jq .VkPhysicalDeviceProperties 2>&1> /dev/null
+exit $?


### PR DESCRIPTION
* Fixes some layouts to point to relevant files in $SNAP/graphics/
* Fixed VK_ICD_FILENAMES to use icd files from the graphics content interface
* Added vkcube, vulkaninfo, glxinfo, and glxgears to apps to ease debugging
* Added a check for connection of the gaming-mesa content interface