### PR TITLE
fix steam-snap.sh that links deb game lib to snap game lib

### DIFF
--- a/src/steam-snap.sh
+++ b/src/steam-snap.sh
@@ -6,15 +6,14 @@ export PATH=$SNAP/bin:$PATH
 
 # If Steam has not bootstrapped, check to see if there is a non-snap
 # Steam library we can adopt.
-STEAMCONFIG=$HOME/.steam
-if [ ! -L $STEAMCONFIG/steam ]; then
-    mkdir -p $STEAMCONFIG
+STEAMCONFIG=$HOME/.local/share
+if [ ! -L $STEAMCONFIG/Steam/steamapps ]; then
+    mkdir -p $STEAMCONFIG/Steam/config
     REALHOME=$(getent passwd $UID | cut -d ':' -f 6)
     if [ -x $REALHOME/.local/share/Steam/steam.sh ]; then
-        ln -s $REALHOME/.local/share/Steam $STEAMCONFIG/steam
-    elif [ -x $REALHOME/Steam/steam.sh ]; then
-        ln -s $REALHOME/Steam $STEAMCONFIG/steam
+        ln -s $REALHOME/.local/share/Steam/steamapps $STEAMCONFIG/Steam
+        ln -s $REALHOME/.local/share/Steam/config/libraryfolders.vdf $STEAMCONFIG/Steam/config/
     fi
 fi
 
-exec $SNAP/bin/steam "$@"
+exec "$@"

--- a/src/steam-snap.sh
+++ b/src/steam-snap.sh
@@ -13,6 +13,9 @@ if [ ! -L $STEAMCONFIG/Steam/steamapps ]; then
     if [ -x $REALHOME/.local/share/Steam/steam.sh ]; then
         ln -s $REALHOME/.local/share/Steam/steamapps $STEAMCONFIG/Steam
         ln -s $REALHOME/.local/share/Steam/config/libraryfolders.vdf $STEAMCONFIG/Steam/config/
+    elif [ -x $REALHOME/.steam/debian-installation/steam.sh ]; then
+        ln -s $REALHOME/.steam/debian-installation/steamapps $STEAMCONFIG/Steam
+        ln -s $REALHOME/.steam/debian-installation/config/libraryfolders.vdf $STEAMCONFIG/Steam/config/
     fi
 fi
 


### PR DESCRIPTION
steamapps is the default games directory. It must exist inside the snap, otherwise it gets created on launch
config/libraryfolders.vdf contains entries for the default games directory + secondary directories