### PR TITLE
Stage xdg-user-dirs as some games seem to expect it to be in $PATH

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -260,6 +260,7 @@ parts:
       - zlib1g:i386
       - zlib1g:amd64
       - xdg-utils
+      - xdg-user-dirs
       - fontconfig-config
       - fontconfig:i386
       - fontconfig:amd64


### PR DESCRIPTION
Stage xdg-user-dirs as some games seem to expect it to be in $PATH, for example Total War: Warhammer II