### PR TITLE
Add summary flag to steam.report

### DIFF
--- a/src/steamreport
+++ b/src/steamreport
@@ -5,11 +5,114 @@ import sys
 import webbrowser
 import argparse
 from collections import defaultdict
+import requests
 
 DISCUSSION_URL = "https://github.com/canonical/steam-snap/discussions/new?category=game-reports"
 WIKI_URL = "https://github.com/canonical/steam-snap/wiki/Troubleshooting#submitting-a-game-report"
+GRAPHQL_URL = "https://api.github.com/graphql"
+TOKEN_URL = "https://github.com/settings/tokens/new"
+
+DISCUSSION_CATEGORY_ID = "DIC_kwDOC5Gtms4CR-_9"
 
 BODY_SUFFIX = "<!--Copy error logs from Steam/the game itself below-->"
+
+def summary():
+    """Summarize discussion data based on labels"""
+    if "GITHUB_ACCESS_TOKEN" not in os.environ:
+        print("Please set the environment variable GITHUB_ACCESS_TOKEN to a valid token")
+        print(f"Generate a token here: {TOKEN_URL}")
+        return
+
+    print("Gathering most recent 100 reports...")
+
+    PDB_RATINGS = [
+        "pdb-borked",
+        "pdb-bronze",
+        "pdb-silver",
+        "pdb-gold",
+        "pdb-platinum",
+        "pdb-native",
+    ]
+    RATINGS = [
+        "borked",
+        "bronze",
+        "silver",
+        "gold",
+        "platinum",
+        "",
+    ]
+
+    access_token = os.environ["GITHUB_ACCESS_TOKEN"]
+    headers = {
+        "Authorization": f"token {access_token}",
+        "Content-Type": "application/json"
+    }
+    response = requests.post(GRAPHQL_URL, headers=headers, json={"query":"""
+        query {
+            repository(owner: "canonical", name: "steam-snap") {
+                discussions(first: 100, categoryId: "%s") {
+                    nodes {
+                        title
+                        labels(first: 10) {
+                            nodes {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """ % (DISCUSSION_CATEGORY_ID)})
+    discussions = response.json()["data"]["repository"]["discussions"]
+
+    total_count = 0
+    counts = {rating: 0 for rating in RATINGS if rating}
+    comparisons = {
+        "worse": 0,
+        "expected": 0,
+        "better": 0
+    }
+
+    for discussion in discussions["nodes"]:
+        labels = discussion["labels"]["nodes"]
+        rating = len(RATINGS) - 1
+        pdb_rating = len(PDB_RATINGS) - 1
+        valid = False
+
+        for label in labels:
+            if label["name"] in counts:
+                counts[label["name"]] += 1
+                valid = True
+                total_count += 1
+            if label["name"] in RATINGS:
+                rating = min(rating, RATINGS.index(label["name"]))
+            if label["name"] in PDB_RATINGS:
+                pdb_rating = min(pdb_rating, PDB_RATINGS.index(label["name"]))
+
+        if valid:
+            if rating > pdb_rating:
+                comparisons["better"] += 1
+            elif rating < pdb_rating:
+                comparisons["worse"] += 1
+            else:
+                comparisons["expected"] += 1
+
+    print(f"Valid reports: {total_count}\n")
+
+    print("Grade Counts")
+    print("------------")
+    print(f"{'Grade':<12} {'Count':<6} {'Percent'}")
+    for count in counts.items():
+        perc = round(count[1] * 100 / total_count, 2)
+        print(f"{count[0].title():<12} {count[1]:<6} {perc:>5} %")
+    print()
+
+    print("Comparisons to ProtonDB")
+    print("-----------------------")
+    print(f"{'Performance':<12} {'Count':<6} {'Percent':<8}")
+    for comparison in comparisons.items():
+        perc = round(comparison[1] * 100 / total_count, 2)
+        print(f"{comparison[0].title():<12} {comparison[1]:<6} {perc:>5} %")
 
 def default():
     return "ERROR"
@@ -66,7 +169,7 @@ def gather_data():
 
     # lspci
     lspci = defaultdict(default)
-    for line in os.popen("lspci | grep -E '(VGA)|(3D controller)'").read().split("\n"):
+    for line in os.popen("lspci | grep -E 'VGA|3D controller'").read().split("\n"):
         line = line.strip()
         if (not line): continue
         key, val = line.split(" ", 1)
@@ -151,7 +254,17 @@ parser.add_argument(
     const=True,
     action="store_const"
 )
+parser.add_argument(
+    "--summary", "-s",
+    help="Display summary of discussion posts. Requires a GitHub key defined in GITHUB_ACCESS_TOKEN.",
+    const=True,
+    action="store_const"
+)
 args = parser.parse_args()
+
+if (args.summary):
+    summary()
+    sys.exit()
 
 # Test environment
 if (not args.force):

--- a/src/steamreport
+++ b/src/steamreport
@@ -18,6 +18,7 @@ BODY_SUFFIX = "<!--Copy error logs from Steam/the game itself below-->"
 
 def summary():
     """Summarize discussion data based on labels"""
+
     if "GITHUB_ACCESS_TOKEN" not in os.environ:
         print("Please set the environment variable GITHUB_ACCESS_TOKEN to a valid token")
         print(f"Generate a token here: {TOKEN_URL}")
@@ -114,25 +115,29 @@ def summary():
         perc = round(comparison[1] * 100 / total_count, 2)
         print(f"{comparison[0].title():<12} {comparison[1]:<6} {perc:>5} %")
 
+
 def default():
     return "ERROR"
 
+
 def dict_to_string(d, n = 0):
     """Convert a dict to yaml-like string."""
+
     s = ""
     for key in d:
         line = f"{'    ' * n}{key}: "
-        if (type(d[key]) is dict):
+        if type(d[key]) is dict:
             line += f"\n{dict_to_string(d[key], n + 1)}"
         else:
             line += f"{' ' * (24 - len(line))}{d[key]}\n"
         s += line
     return s
 
+
 def gather_data():
     """Gathers system information, returning a data object."""
-    data = {}
 
+    data = {}
     # /etc/os-release
     os_release = defaultdict(default)
     os_release_lookup = [
@@ -153,7 +158,7 @@ def gather_data():
         except FileNotFoundError:
             continue
 
-    if (args.verbose):
+    if args.verbose:
         data["os_release"] = dict(os_release)
     else:
         data["os_release"] = {
@@ -171,7 +176,7 @@ def gather_data():
     lspci = defaultdict(default)
     for line in os.popen("lspci | grep -E 'VGA|3D controller'").read().split("\n"):
         line = line.strip()
-        if (not line): continue
+        if not line: continue
         key, val = line.split(" ", 1)
         val = val.strip()\
             .removeprefix("VGA compatible controller: ")\
@@ -184,11 +189,11 @@ def gather_data():
     glxinfo = defaultdict(default)
     for line in os.popen("glxinfo -B").read().split("\n"):
         line = line.strip()
-        if (not line): continue
+        if not line: continue
         key, val = line.split(":", 1)
         glxinfo[key.strip()] = val.strip()
 
-    if (args.verbose):
+    if args.verbose:
         data["glxinfo"] = dict(glxinfo)
     else:
         data["glxinfo"] = {
@@ -204,7 +209,7 @@ def gather_data():
         key, val = line.split(":", 1)
         lscpu[key.strip()] = val.strip()
 
-    if (args.verbose):
+    if args.verbose:
         data["lscpu"] = dict(lscpu)
     else:
         data["lscpu"] = {
@@ -217,14 +222,17 @@ def gather_data():
 
     return data
 
+
 def submit_data(data):
     """Open web-browser and fill in system information."""
+
     url = DISCUSSION_URL
     url += f"&title=Report: {args.title.title()}"
     url += f"&body=```\n{dict_to_string(data)}```\n".replace("\n", "%0A")
     url += BODY_SUFFIX
     print("Opening web browser...")
     webbrowser.open_new_tab(url)
+
 
 # Parse commandline arguments
 parser = argparse.ArgumentParser(
@@ -262,25 +270,25 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-if (args.summary):
+if args.summary:
     summary()
     sys.exit()
 
 # Test environment
-if (not args.force):
-    if (not os.environ.get("SNAP")):
+if not args.force:
+    if not os.environ.get("SNAP"):
         sys.exit(
             "This script must be ran from inside a Snap environment.\n" +
             "Run `snap run steam.report`."
         )
 
-    if (os.system("snapctl is-connected system-observe")):
+    if os.system("snapctl is-connected system-observe"):
         sys.exit(
             "This script relies on the system-observe Snap plug.\n" +
             "Outside of the snap, run `snap connect steam:system-observe`."
         )
 
-    if (os.system("snapctl is-connected hardware-observe")):
+    if os.system("snapctl is-connected hardware-observe"):
         sys.exit(
             "This script relies on the hardware-observe Snap plug.\n" +
             "Outside of the snap, run `snap connect steam:hardware-observe`."
@@ -289,5 +297,5 @@ if (not args.force):
 # Gather and submit data
 data = gather_data()
 print(dict_to_string(data))
-if (not args.no_submit):
+if not args.no_submit:
     submit_data(data)


### PR DESCRIPTION
Example:
```
$ GITHUB_ACCESS_TOKEN="my_github_token" src/steamreport --summary
Gathering most recent 100 reports...
Valid reports: 65

Grade Counts
------------
Grade        Count  Percent
Borked       18     27.69 %
Bronze       2       3.08 %
Silver       8      12.31 %
Gold         17     26.15 %
Platinum     20     30.77 %

Comparisons to ProtonDB
-----------------------
Performance  Count  Percent 
Worse        37     56.92 %
Expected     21     32.31 %
Better       7      10.77 %
```

"Grade Counts" just counts the number of discussion posts with labels like `bronze`, `silver`, `gold`, etc. "Comparisons to ProtonDB" compares the snap's grade (`bronze`, `silver`, etc.) with the ProtonDB grade (`pdb-bronze`, `pdb-silver`, etc.) and determines if the snap grade is worse, expected, or better than the ProtonDB grade.

The discussion endpoint requires authentication, so this does require a GitHub access token defined in the `GITHUB_ACCESS_TOKEN` environment variable. A (classic) personal access token with no additional permissions granted should be sufficient.

The discussions API is paginated with a maximum of 100 per page, which I think plays well with only using newer, more relevant posts. If we want to summarize *all* posts, I could change it to do that instead.