### PR TITLE
Remove superfluous layout specifiers

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,40 +42,17 @@ layout:
     bind: $SNAP/graphics/usr/share/libdrm
   /usr/share/drirc.d:
     bind: $SNAP/graphics/usr/share/drirc.d
-  /usr/share/glvnd/egl_vendor.d:
-    bind: $SNAP/graphics/usr/share/glvnd/egl_vendor.d
   /usr/lib/x86_64-linux-gnu/alsa-lib:
     bind: $SNAP/usr/lib/x86_64-linux-gnu/alsa-lib
   /usr/share/alsa:
     bind: $SNAP/usr/share/alsa
-  /usr/share/X11/xkb:
-    bind: $SNAP/usr/share/X11/xkb
-  /usr/lib/x86_64-linux-gnu/libvulkan_intel.so:
-    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_intel.so
-  /usr/lib/i386-linux-gnu/libvulkan_intel.so:
-    symlink: $SNAP/graphics/usr/lib/i386-linux-gnu/libvulkan_intel.so
-  /usr/lib/x86_64-linux-gnu/libvulkan_lvp.so:
-    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_lvp.so
-  /usr/lib/i386-linux-gnu/libvulkan_lvp.so:
-    symlink: $SNAP/graphics/usr/lib/i386-linux-gnu/libvulkan_lvp.so
-  /usr/lib/x86_64-linux-gnu/libvulkan_radeon.so:
-    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_radeon.so
-  /usr/lib/i386-linux-gnu/libvulkan_radeon.so:
-    symlink: $SNAP/graphics/usr/lib/i386-linux-gnu/libvulkan_radeon.so
-  /usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0:
-    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
-  /usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0:
-    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0.0.0
-  /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0:
-    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
-  /usr/lib/x86_64-linux-gnu/libxcb.so:
-    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
-  /usr/lib/x86_64-linux-gnu/libxcb.so.1:
-    symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0
   /etc/ld.so.cache:
     bind-file: $SNAP_DATA/etc/ld.so.cache
   /etc/fonts:
     bind: $SNAP/etc/fonts
+
+### !!! ATTENTION - Do not put environment variables like LD_LIBRARY_PATH or graphics ones in the snapcraft.yaml
+### under environment! This are handled in the launch script src/desktop-launch, and duplicating them in both makes things confusing.
 
 plugs:
   gaming-mesa:
@@ -109,10 +86,6 @@ hooks:
   configure:
     plugs:
       - opengl
-
-environment:
-  LD_LIBRARY_PATH: $SNAP/graphics/lib/i386-linux-gnu:$SNAP/graphics/usr/lib:$SNAP/usr/lib/i386-linux-gnu:$SNAP/lib/i386-linux-gnu:$SNAP/usr/lib/i386-linux-gnu/pulseaudio${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-  LIBGL_DRIVERS_PATH: $SNAP/graphics/usr/lib/i386-linux-gnu/dri:$SNAP/graphics/usr/lib/x86_64-linux-gnu/dri:${LIBGL_DRIVERS_PATH:+:$LIBGL_DRIVERS_PATH}
 
 parts:
   launcher:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,10 +33,6 @@ package-repositories:
     key-id: BA1816EF8E75005FCF5E27A1F24AEA9FB05498B7
 
 layout:
-  /usr/lib/steam:
-    bind: $SNAP/usr/lib/steam
-  /usr/share/zenity:
-    bind: $SNAP/usr/share/zenity
   # https://discourse.ubuntu.com/t/the-graphics-core20-snap-interface/23000
   /usr/share/libdrm:
     bind: $SNAP/graphics/usr/share/libdrm

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,14 +42,8 @@ layout:
     bind: $SNAP/graphics/usr/share/libdrm
   /usr/share/drirc.d:
     bind: $SNAP/graphics/usr/share/drirc.d
-  /usr/lib/x86_64-linux-gnu/alsa-lib:
-    bind: $SNAP/usr/lib/x86_64-linux-gnu/alsa-lib
-  /usr/share/alsa:
-    bind: $SNAP/usr/share/alsa
   /etc/ld.so.cache:
     bind-file: $SNAP_DATA/etc/ld.so.cache
-  /etc/fonts:
-    bind: $SNAP/etc/fonts
 
 ### !!! ATTENTION - Do not put environment variables like LD_LIBRARY_PATH or graphics ones in the snapcraft.yaml
 ### under environment! This are handled in the launch script src/desktop-launch, and duplicating them in both makes things confusing.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,6 +40,9 @@ layout:
     bind: $SNAP/graphics/usr/share/drirc.d
   /etc/ld.so.cache:
     bind-file: $SNAP_DATA/etc/ld.so.cache
+  # Needed for a first install, obnoxiously hard to work around
+  /usr/lib/steam:
+    bind: $SNAP/usr/lib/steam
 
 ### !!! ATTENTION - Do not put environment variables like LD_LIBRARY_PATH or graphics ones in the snapcraft.yaml
 ### under environment! This are handled in the launch script src/desktop-launch, and duplicating them in both makes things confusing.
@@ -289,7 +292,6 @@ parts:
       find . -type f,l -exec rm -f $CRAFT_PRIME/usr/lib/{} \;
       cd /snap/gaming-graphics-core22/current/usr/share
       find . -type f,l -exec rm -f $CRAFT_PRIME/usr/share/{} \;
-
 
 apps:
   steam:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,8 @@ layout:
   # Needed for a first install, obnoxiously hard to work around
   /usr/lib/steam:
     bind: $SNAP/usr/lib/steam
+  /usr/share/zenity:
+    bind: $SNAP/usr/share/zenity
 
 ### !!! ATTENTION - Do not put environment variables like LD_LIBRARY_PATH or graphics ones in the snapcraft.yaml
 ### under environment! This are handled in the launch script src/desktop-launch, and duplicating them in both makes things confusing.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,10 @@ layout:
     bind: $SNAP/graphics/usr/share/libdrm
   /usr/share/drirc.d:
     bind: $SNAP/graphics/usr/share/drirc.d
+  /usr/share/alsa:
+    bind: $SNAP/usr/share/alsa
+  /usr/share/X11/xkb:
+    bind: $SNAP/usr/share/X11/xkb
   /etc/ld.so.cache:
     bind-file: $SNAP_DATA/etc/ld.so.cache
   # Needed for a first install, obnoxiously hard to work around

--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -153,6 +153,10 @@ export XLOCALEDIR="$SNAP_DESKTOP_RUNTIME/usr/share/X11/locale"
 export XCURSOR_PATH="$SNAP_DESKTOP_RUNTIME/usr/share/icons"
 prepend_dir XCURSOR_PATH "$SNAP/share/icons"
 
+### Fonts
+
+export FONTCONFIG_PATH="$SNAP/etc/fonts"
+
 #### Setting up graphics content snap paths
 
 GRAPHICS_CORE_LIB="$SNAP_DESKTOP_RUNTIME/graphics/usr/lib"

--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -184,14 +184,6 @@ append_dir __EGL_VENDOR_LIBRARY_DIRS "$GRAPHICS_CORE_SHARE/glvnd/egl_vendor.d"
 append_dir LIBVA_DRIVERS_PATH "$GRAPHICS_CORE_LIB/i386-linux-gnu/dri"
 append_dir LIBVA_DRIVERS_PATH "$GRAPHICS_CORE_LIB/x86_64-linux-gnu/dri"
 
-# Set where the VDPAU drivers are located
-export VDPAU_DRIVER_PATH="$GRAPHICS_CORE_LIB/i386-linux-gnu/vdpau/"
-if [ -e "/var/lib/snapd/lib/gl/vdpau/libvdpau_nvidia.so" ]; then
-  export VDPAU_DRIVER_PATH="/var/lib/snapd/lib/gl/vdpau"
-  # Prevent picking VA-API (Intel/AMD) over NVIDIA VDPAU; on PRIME systems for example
-  unset LIBVA_DRIVERS_PATH
-fi
-
 # Export Vulkan ICD filename paths
 export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$GRAPHICS_CORE_SHARE/vulkan/icd.d/radeon_icd.x86_64.json:$GRAPHICS_CORE_SHARE/vulkan/icd.d/radeon_icd.i686.json:$GRAPHICS_CORE_SHARE/vulkan/icd.d/intel_icd.x86_64.json:$GRAPHICS_CORE_SHARE/vulkan/icd.d/intel_icd.i686.json"
 

--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -71,21 +71,13 @@ if [[ -d $SNAP_USER_DATA/.config ]]; then
   rm -r $SNAP_USER_DATA/.config
 fi
 
-if [ "$SNAP_ARCH" = "amd64" ]; then
-  ARCH="x86_64-linux-gnu"
-elif [ "$SNAP_ARCH" = "armhf" ]; then
-  ARCH="arm-linux-gnueabihf"
-elif [ "$SNAP_ARCH" = "arm64" ]; then
-  ARCH="aarch64-linux-gnu"
-elif [ "$SNAP_ARCH" = "ppc64el" ]; then
-  ARCH="powerpc64le-linux-gnu"
+# We need to force our snap's arch to i386, but this only works on an i386 compatible arch
+if [ "$SNAP_ARCH" = "amd64" ] || [ "$SNAP_ARCH" = "i386" ]; then
+  export SNAP_LAUNCHER_ARCH_TRIPLET="i386-linux-gnu"
 else
-  ARCH="$SNAP_ARCH-linux-gnu"
+  echo "UNSUPPORTED ARCH $SNAP_ARCH - only i386 and x86_64 are supported"
+  exit 1
 fi
-
-# Force i386
-export ARCH="i386-linux-gnu"
-export SNAP_LAUNCHER_ARCH_TRIPLET="$ARCH"
 
 ###############################################
 # Launcher common exports for any desktop app #
@@ -161,33 +153,31 @@ export XLOCALEDIR="$SNAP_DESKTOP_RUNTIME/usr/share/X11/locale"
 export XCURSOR_PATH="$SNAP_DESKTOP_RUNTIME/usr/share/icons"
 prepend_dir XCURSOR_PATH "$SNAP/share/icons"
 
-# Mesa Libs for OpenGL support
-append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/mesa"
-append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/mesa-egl"
-append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/x86_64-linux-gnu/mesa"
-append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/x86_64-linux-gnu/mesa-egl"
-# append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/graphics/usr/lib/$ARCH/mesa"
-# append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/graphics/usr/lib/$ARCH/mesa-egl"
-# append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/graphics/usr/lib/x86_64-linux-gnu/mesa"
-# append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/graphics/usr/lib/x86_64-linux-gnu/mesa-egl"
+#### Setting up graphics content snap paths
 
-append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/graphics/usr/lib/$ARCH"
-append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/graphics/usr/lib/x86_64-linux-gnu"
+GRAPHICS_CORE_LIB="$SNAP_DESKTOP_RUNTIME/graphics/usr/lib"
+
+# Mesa Libs for OpenGL support
+append_dir LD_LIBRARY_PATH "$GRAPHICS_CORE_LIB/i386-linux-gnu/mesa"
+append_dir LD_LIBRARY_PATH "$GRAPHICS_CORE_LIB/i386-linux-gnu/mesa-egl"
+append_dir LD_LIBRARY_PATH "$GRAPHICS_CORE_LIB/x86_64-linux-gnu/mesa"
+append_dir LD_LIBRARY_PATH "$GRAPHICS_CORE_LIB/x86_64-linux-gnu/mesa-egl"
+append_dir LD_LIBRARY_PATH "$GRAPHICS_CORE_LIB/i386-linux-gnu"
+append_dir LD_LIBRARY_PATH "$GRAPHICS_CORE_LIB/x86_64-linux-gnu"
 
 # Tell libGL and libva where to find the drivers
-export LIBGL_DRIVERS_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/dri"
-append_dir LIBGL_DRIVERS_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/x86_64-linux-gnu/dri"
-append_dir LIBGL_DRIVERS_PATH "$SNAP_DESKTOP_RUNTIME/graphics/usr/lib/$ARCH/dri"
-append_dir LIBGL_DRIVERS_PATH "$SNAP_DESKTOP_RUNTIME/graphics/usr/lib/x86_64-linux-gnu/dri"
-append_dir LD_LIBRARY_PATH "$LIBGL_DRIVERS_PATH"
+export LIBGL_DRIVERS_PATH="$GRAPHICS_CORE_LIB/i386-linux-gnu/dri"
+append_dir LIBGL_DRIVERS_PATH "$GRAPHICS_CORE_LIB/x86_64-linux-gnu/dri"
 
-append_dir LIBVA_DRIVERS_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/dri"
-append_dir LIBVA_DRIVERS_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/x86_64-linux-gnu/dri"
-append_dir LIBVA_DRIVERS_PATH "$SNAP_DESKTOP_RUNTIME/graphics/usr/lib/$ARCH/dri"
-append_dir LIBVA_DRIVERS_PATH "$SNAP_DESKTOP_RUNTIME/graphics/usr/lib/x86_64-linux-gnu/dri"
+# EGL vendor files on glvnd enabled systems
+prepend_dir __EGL_VENDOR_LIBRARY_DIRS "/var/lib/snapd/lib/glvnd/egl_vendor.d"
+append_dir __EGL_VENDOR_LIBRARY_DIRS "$SNAP_DESKTOP_RUNTIME/graphics/usr/share/glvnd/egl_vendor.d"
+
+append_dir LIBVA_DRIVERS_PATH "$GRAPHICS_CORE_LIB/i386-linux-gnu/dri"
+append_dir LIBVA_DRIVERS_PATH "$GRAPHICS_CORE_LIB/x86_64-linux-gnu/dri"
 
 # Set where the VDPAU drivers are located
-export VDPAU_DRIVER_PATH="/usr/lib/$ARCH/vdpau/"
+export VDPAU_DRIVER_PATH="$GRAPHICS_CORE_LIB/i386-linux-gnu/vdpau/"
 if [ -e "/var/lib/snapd/lib/gl/vdpau/libvdpau_nvidia.so" ]; then
   export VDPAU_DRIVER_PATH="/var/lib/snapd/lib/gl/vdpau"
   # Prevent picking VA-API (Intel/AMD) over NVIDIA VDPAU; on PRIME systems for example
@@ -205,20 +195,16 @@ append_dir LD_LIBRARY_PATH "/var/lib/snapd/lib/gl"
 append_dir LD_LIBRARY_PATH "/var/lib/snapd/lib/gl/vdpau"
 
 # Unity7 export (workaround for https://launchpad.net/bugs/1638405)
-append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libunity"
+append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/i386-linux-gnu/libunity"
 
 # Pulseaudio export
-append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/pulseaudio"
-
-# EGL vendor files on glvnd enabled systems
-prepend_dir __EGL_VENDOR_LIBRARY_DIRS "/var/lib/snapd/lib/glvnd/egl_vendor.d"
-append_dir __EGL_VENDOR_LIBRARY_DIRS "$SNAP_DESKTOP_RUNTIME/usr/share/glvnd/egl_vendor.d"
+append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/i386-linux-gnu/pulseaudio"
 
 # Tell GStreamer where to find its plugins
-export GST_PLUGIN_PATH="$SNAP/usr/lib/$ARCH/gstreamer-1.0"
-export GST_PLUGIN_SYSTEM_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gstreamer-1.0"
+export GST_PLUGIN_PATH="$SNAP/usr/lib/i386-linux-gnu/gstreamer-1.0"
+export GST_PLUGIN_SYSTEM_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/i386-linux-gnu/gstreamer-1.0"
 # gst plugin scanner doesn't install in the correct path: https://github.com/ubuntu/snapcraft-desktop-helpers/issues/43
-export GST_PLUGIN_SCANNER="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner"
+export GST_PLUGIN_SCANNER="$SNAP_DESKTOP_RUNTIME/usr/lib/i386-linux-gnu/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner"
 
 # XDG Config
 prepend_dir XDG_CONFIG_DIRS "$SNAP_DESKTOP_RUNTIME/etc/xdg"
@@ -309,7 +295,7 @@ if [ "$wayland_available" = true ]; then
   # Does not hurt to specify this as well, just in case
   export QT_QPA_PLATFORM=wayland-egl
 fi
-append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gtk-3.0"
+append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/i386-linux-gnu/gtk-3.0"
 
 ###############################
 # Mark update and exec binary #

--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -156,6 +156,7 @@ prepend_dir XCURSOR_PATH "$SNAP/share/icons"
 #### Setting up graphics content snap paths
 
 GRAPHICS_CORE_LIB="$SNAP_DESKTOP_RUNTIME/graphics/usr/lib"
+GRAPHICS_CORE_SHARE="$SNAP_DESKTOP_RUNTIME/graphics/usr/share"
 
 # Mesa Libs for OpenGL support
 append_dir LD_LIBRARY_PATH "$GRAPHICS_CORE_LIB/i386-linux-gnu/mesa"
@@ -165,13 +166,16 @@ append_dir LD_LIBRARY_PATH "$GRAPHICS_CORE_LIB/x86_64-linux-gnu/mesa-egl"
 append_dir LD_LIBRARY_PATH "$GRAPHICS_CORE_LIB/i386-linux-gnu"
 append_dir LD_LIBRARY_PATH "$GRAPHICS_CORE_LIB/x86_64-linux-gnu"
 
+# Ensure nvidia driver libs are loaded
+prepend_dir LD_LIBRARY_PATH "/var/lib/snapd/lib/gl/"
+
 # Tell libGL and libva where to find the drivers
 export LIBGL_DRIVERS_PATH="$GRAPHICS_CORE_LIB/i386-linux-gnu/dri"
 append_dir LIBGL_DRIVERS_PATH "$GRAPHICS_CORE_LIB/x86_64-linux-gnu/dri"
 
 # EGL vendor files on glvnd enabled systems
 prepend_dir __EGL_VENDOR_LIBRARY_DIRS "/var/lib/snapd/lib/glvnd/egl_vendor.d"
-append_dir __EGL_VENDOR_LIBRARY_DIRS "$SNAP_DESKTOP_RUNTIME/graphics/usr/share/glvnd/egl_vendor.d"
+append_dir __EGL_VENDOR_LIBRARY_DIRS "$GRAPHICS_CORE_SHARE/glvnd/egl_vendor.d"
 
 append_dir LIBVA_DRIVERS_PATH "$GRAPHICS_CORE_LIB/i386-linux-gnu/dri"
 append_dir LIBVA_DRIVERS_PATH "$GRAPHICS_CORE_LIB/x86_64-linux-gnu/dri"
@@ -185,7 +189,7 @@ if [ -e "/var/lib/snapd/lib/gl/vdpau/libvdpau_nvidia.so" ]; then
 fi
 
 # Export Vulkan ICD filename paths
-export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/graphics/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:$SNAP/graphics/usr/share/vulkan/icd.d/radeon_icd.i686.json:$SNAP/graphics/usr/share/vulkan/icd.d/intel_icd.x86_64.json:$SNAP/graphics/usr/share/vulkan/icd.d/intel_icd.i686.json"
+export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$GRAPHICS_CORE_SHARE/vulkan/icd.d/radeon_icd.x86_64.json:$GRAPHICS_CORE_SHARE/vulkan/icd.d/radeon_icd.i686.json:$GRAPHICS_CORE_SHARE/vulkan/icd.d/intel_icd.x86_64.json:$GRAPHICS_CORE_SHARE/vulkan/icd.d/intel_icd.i686.json"
 
 # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
 # /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH
@@ -193,6 +197,12 @@ export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/g
 # Ref.: https://bugs.launchpad.net/snappy/+bug/1588192
 append_dir LD_LIBRARY_PATH "/var/lib/snapd/lib/gl"
 append_dir LD_LIBRARY_PATH "/var/lib/snapd/lib/gl/vdpau"
+
+
+### Audio stuff
+
+append_dir LD_LIBRARY_PATH "$SNAP/usr/lib/x86_64-linux-gnu/alsa-lib"
+append_dir LD_LIBRARY_PATH "$SNAP/usr/share/alsa"
 
 # Unity7 export (workaround for https://launchpad.net/bugs/1638405)
 append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/i386-linux-gnu/libunity"

--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -184,8 +184,18 @@ append_dir __EGL_VENDOR_LIBRARY_DIRS "$GRAPHICS_CORE_SHARE/glvnd/egl_vendor.d"
 append_dir LIBVA_DRIVERS_PATH "$GRAPHICS_CORE_LIB/i386-linux-gnu/dri"
 append_dir LIBVA_DRIVERS_PATH "$GRAPHICS_CORE_LIB/x86_64-linux-gnu/dri"
 
+### Fix for Vulkan ICD paths being hardcoded under root
+
+VULKAN_OVERRIDES=$SNAP_USER_COMMON/.vulkan/icd.d
+mkdir -p $VULKAN_OVERRIDES
+
+ICDs=$GRAPHICS_CORE_SHARE/vulkan/icd.d/; 
+for f in $(ls $ICDs); do 
+  cat "$ICDs/$f" | jq '.ICD.library_path=$prefix+.ICD.library_path' --arg prefix "$SNAP/graphics" > "$VULKAN_OVERRIDES/$f"
+done
+
 # Export Vulkan ICD filename paths
-export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$GRAPHICS_CORE_SHARE/vulkan/icd.d/radeon_icd.x86_64.json:$GRAPHICS_CORE_SHARE/vulkan/icd.d/radeon_icd.i686.json:$GRAPHICS_CORE_SHARE/vulkan/icd.d/intel_icd.x86_64.json:$GRAPHICS_CORE_SHARE/vulkan/icd.d/intel_icd.i686.json"
+export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$VULKAN_OVERRIDES/radeon_icd.x86_64.json:$VULKAN_OVERRIDES/radeon_icd.i686.json:$VULKAN_OVERRIDES/intel_icd.x86_64.json:$VULKAN_OVERRIDES/intel_icd.i686.json"
 
 # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
 # /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH


### PR DESCRIPTION
This removes all the layout specifiers not related to libdrm (which has to be in a specific place right now), but otherwise prefers using environment variables to layout for driver location paths.

This also culls a lot of layout specifiers that turned out to be unnecessary (such as ALSA and zenity) - these are in their own commits for easy reversion.

This *does* need to be tested by someone with legacy big picture mode (unless legacy big picture no longer exists for anyone?), because it sets a fontconfig variable and we need to make sure we don't re-break that. This also needs testing on intel prime systems, as a workaround was removed as it prevents libva from loading on non-hybrid nvidia.