### PR TITLE
Revert "Update MangoHUD to 0.6.9-1"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -205,7 +205,7 @@ parts:
   mangohud:
     after: [meson-deps]
     source: https://github.com/flightlessmango/MangoHud.git
-    source-tag: "v0.6.9-1"
+    source-tag: "v0.6.8"
     plugin: meson
     organize:
       snap/steam/current/usr: usr
@@ -235,7 +235,7 @@ parts:
   mangohud64:
     after: [meson-deps, mangohud]
     source: https://github.com/flightlessmango/MangoHud.git
-    source-tag: "v0.6.9-1"
+    source-tag: "v0.6.8"
     plugin: meson
     organize:
       snap/steam/current/usr: usr


### PR DESCRIPTION
Reverts update to 0.6.9-1 (from 0.6.8).

Version 0.6.9+ seems to not work well, reverting 0.6.8 seems to allow it to work as well as expected.