### PR TITLE
Move test logic to tests/vulkan

### DIFF
--- a/src/vulkaninfo
+++ b/src/vulkaninfo
@@ -1,13 +1,4 @@
 #!/bin/bash
 
-set -e
-
-# vulkaninfo --json always saves a file so we have to do this sadly...
-mkdir -p $SNAP_USER_COMMON
-vulkaninfo --json -o $SNAP_USER_COMMON/vkinfodump.json
-# Find if any level has some physical device property info
-jq -e 'any(paths; .[-1] == "VkPhysicalDeviceProperties")' "$SNAP_USER_COMMON/vkinfodump.json" 2>&1> /dev/null
-result=$?
-rm $SNAP_USER_COMMON/vkinfodump.json
-
-exit $result
+exec $SNAP/graphics/usr/bin/vulkaninfo "$@"
+exit $?

--- a/tests/vulkan
+++ b/tests/vulkan
@@ -1,4 +1,13 @@
 #!/bin/bash
 
-vulkaninfo --json 2>/dev/null | jq .VkPhysicalDeviceProperties 2>&1> /dev/null
-exit $?
+set -e
+
+# To properly get an exit status from jq we need to save to a file first
+mkdir -p $SNAP_USER_COMMON
+vulkaninfo --json -o $SNAP_USER_COMMON/vkinfodump.json
+# Find if any level has some physical device property info
+jq -e 'any(paths; .[-1] == "VkPhysicalDeviceProperties")' "$SNAP_USER_COMMON/vkinfodump.json" 2>&1> /dev/null
+result=$?
+rm $SNAP_USER_COMMON/vkinfodump.json
+
+exit $result


### PR DESCRIPTION
`src/vulkaninfo` was recursively calling itself, causing it to error (and no output was generated), so its logic has been moved to `tests/vulkan` instead.

Fixes #241