### PR TITLE
snap: connect to the network-bind interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -399,6 +399,7 @@ apps:
       - system-observe
       - joystick
       - network
+      - network-bind
       - opengl
       - audio-playback
       - audio-record


### PR DESCRIPTION
snap: connect to the network-bind interface, necessary on systems where desktop-legacy isn't supported like Ubuntu Core Desktop.