### PR TITLE
Reduce staged files for GDK dialogs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -129,7 +129,6 @@ parts:
       - usr/lib/python3/dist-packages/*
       - usr/share/mime/*
       - usr/share/icons/*
-      - usr/**/girepository-1.0*
       - usr/lib/**/gtk-3.0*
       - etc/gtk-3.0*
       - usr/share/*/gir1.2-gtk-3.0*
@@ -149,7 +148,7 @@ parts:
       - usr/**/libepoxy*
       - usr/**/libfontconfig*
       - usr/**/libfribidi*
-      - usr/**/libgirepository-1*
+      - usr/**/*girepository*
       - usr/**/libgraphite2*
       - usr/**/libgtk-3*
       - usr/**/libharfbuzz*
@@ -465,6 +464,7 @@ apps:
     command-chain: [bin/desktop-launch]
     command: bin/steamreport
     environment:
+      DISABLE_WAYLAND: 1
       PYTHONPATH: $SNAP/usr/lib/python3/dist-packages
       GI_TYPELIB_PATH: $SNAP/usr/lib/x86_64-linux-gnu/girepository-1.0
     plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -125,8 +125,48 @@ parts:
       - python3-gi
       - gir1.2-gtk-3.0
     stage:
-      - -usr/bin/fc-*
-      - -usr/share/doc/fontconfig/fontconfig-user.*
+      - bin/*
+      - usr/lib/python3/dist-packages/*
+      - usr/share/mime/*
+      - usr/share/icons/*
+      - usr/**/girepository-1.0*
+      - usr/lib/**/gtk-3.0*
+      - etc/gtk-3.0*
+      - usr/share/*/gir1.2-gtk-3.0*
+      - usr/share/*/libgtk-3*
+      - usr/**/libfontconfig*
+      - usr/**/cairo-1*
+      - usr/**/libatspi*
+      - usr/**/libavahi-client*
+      - usr/**/libavahi-common*
+      - usr/**/libcairo-gobject*
+      - usr/**/libcairo*
+      - usr/**/libcolord*
+      - usr/**/libcups*
+      - usr/**/libdatrie*
+      - usr/**/libdconf*
+      - usr/**/libdeflate*
+      - usr/**/libepoxy*
+      - usr/**/libfontconfig*
+      - usr/**/libfribidi*
+      - usr/**/libgirepository-1*
+      - usr/**/libgraphite2*
+      - usr/**/libgtk-3*
+      - usr/**/libharfbuzz*
+      - usr/**/libjbig*
+      - usr/**/libjpeg*
+      - usr/**/liblcms2*
+      - usr/**/libpango-1*
+      - usr/**/libpangocairo-1*
+      - usr/**/libpangoft2-1*
+      - usr/**/libpangoxft-1*
+      - usr/**/libpixman-1*
+      - usr/**/libthai*
+      - usr/**/libtiff*
+      - usr/**/libwayland-cursor*
+      - usr/**/libwebp*
+      - usr/**/libxcb-render*
+      - usr/**/libxkbcommon*
 
   alsa-mixin:
     plugin: dump


### PR DESCRIPTION
Reduces the amount of files to be staged for the GDK dialogs.

Currently reduces the size of the Snap from 216 MB pre-reduction to 198 MB post-reduction (still up from the 191 MB Steam in stable that does not have dialogs).