### PR TITLE
Fix lsof and xdg-user-dir not found

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -124,6 +124,8 @@ parts:
     stage-packages:
       - python3-gi
       - gir1.2-gtk-3.0
+      - lsof
+      - xdg-user-dirs
     stage:
       - bin/*
       - usr/lib/python3/dist-packages/*


### PR DESCRIPTION
When doing a microphone test, the screen shows the errors

    lsof: not found
    xdg-user-dir: not found

this patch fixes it.