### PR TITLE
Fix dbus error

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -360,6 +360,7 @@ parts:
       - lsof
       - locales-all
       - usbutils # Allows finding controllers etc
+      - psmisc
     override-build: |
       craftctl default
       # Set the snap version from the .deb package version

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -105,6 +105,12 @@ plugs:
     interface: shared-memory
     private: true
 
+slots:
+  steam:
+    interface: dbus
+    bus: session
+    name: com.steampowered.PressureVessel.LaunchAlongsideSteam
+
 hooks:
   configure:
     plugs:

--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -330,4 +330,5 @@ if [ -n "$SNAP_DESKTOP_DEBUG" ]; then
 fi
 
 $SNAP/bin/nvidia32 &
-exec "$@"
+"$@"
+killall steam-runtime-launcher-service


### PR DESCRIPTION
Steam tries to create the com.steampowered.PressureVessel.LaunchAlongsideSteam DBus entry, but it returns an error.

This patch fixes it.