### PR TITLE
Update bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,9 +58,9 @@ body:
   validations:
     required: false
 - type: textarea
+  id: environment
   attributes:
     label: Environment
-    id: environment
     description: |
       Output of `snap run steam.report`. More info on this command [here](https://github.com/canonical/steam-snap/wiki/Troubleshooting#submitting-a-steam-report).
     placeholder: |


### PR DESCRIPTION
This fixes the autofill feature of steamreport, `id` was placed in the wrong block