### PR TITLE
Add fuse

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -376,6 +376,8 @@ parts:
       - locales-all
       - usbutils # Allows finding controllers etc
       - psmisc
+      - libfuse2:amd64
+      - libfuse2:i386
     override-build: |
       craftctl default
       # Set the snap version from the .deb package version

--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -347,6 +347,13 @@ strip_unreachable_dirs XDG_DATA_DIRS
 strip_unreachable_dirs XDG_CONFIG_DIRS
 strip_unreachable_dirs XDG_SPECIAL_DIRS
 
+# Even with libfuse, appimages need to be extracted to run.
+# This is a workaround until we figure out something better, because it makes
+# launching AppImage games way slower
+#
+# That said, they're really rare so it's not a big deal
+export APPIMAGE_EXTRACT_AND_RUN=1
+
 $SNAP/bin/nvidia32 &
 "$@"
 killall steam-runtime-launcher-service


### PR DESCRIPTION
Fixes the initial error with Fuse/Appimage games. Games still have mount permissions errors