### PR TITLE
Fix amdgpu.ids bind

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,8 +38,8 @@ layout:
   /usr/share/zenity:
     bind: $SNAP/usr/share/zenity
   # https://discourse.ubuntu.com/t/the-graphics-core20-snap-interface/23000
-  /usr/share/libdrm:
-    bind: $SNAP/graphics/usr/share/libdrm
+  /usr/share/libdrm/amdgpu.ids:
+    bind-file: $SNAP/graphics/usr/share/libdrm/amdgpu.ids
   /usr/share/drirc.d:
     bind: $SNAP/graphics/usr/share/drirc.d
   /usr/share/glvnd/egl_vendor.d:


### PR DESCRIPTION
Binding or symlinking the `libdrm` directory just leads to an empty directory. The only file we need (and the only one that exists) in that directory is `amdgpu.ids`, so this PR just binds the file directly.

Fixes https://github.com/canonical/steam-snap/issues/176
