### PR TITLE
ci: Add Jira sync action

### DIFF
--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -1,0 +1,13 @@
+name: Sync GitHub issues to Jira
+on: [issues, issue_comment]
+
+jobs:
+  sync-issues:
+    name: Sync issues to Jira
+    runs-on: ubuntu-latest
+    steps:
+      - uses: canonical/sync-issues-github-jira@v1
+        with:
+          webhook-url: ${{ secrets.JIRA_WEBHOOK_URL }}
+          component: 'Gaming'
+          label: 'jira'


### PR DESCRIPTION
Adds the [Jira sync action](https://github.com/canonical/sync-issues-github-jira). I've added `JIRA_WEBHOOK_URL` to our repo secrets.