### PR TITLE
Fix issue templates and provide clearer directions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,32 +1,20 @@
 name: Bug Report
 description: Create an issue about a problem with the Snap
 title: "<title>"
-labels: [bug]
+labels: [type/bug]
 body:
 - type: checkboxes
   attributes:
-    label: Is there an existing issue for this?
+    label: Ensure there isn't an existing issue for this and check the wiki
     description: |
-      Please search to see if an issue already exists for the bug you encountered: https://github.com/canonical/steam-snap/issues?q=label%3Abug.
+      Please search to see if an issue already exists for the bug you encountered: https://github.com/canonical/steam-snap/issues?q=label%3Atype%2Fbug.
+
+      Be sure to check the [wiki](https://github.com/canonical/steam-snap/wiki) to see if your issue is addressed.
+
+      If you are able, it is helpful to test if the problem occurs on the deb version of Steam or not.
     options:
-    - label: I have searched the existing issues
+    - label: This issue is not a duplicate and I have checked the wiki.
       required: true
-- type: checkboxes
-  attributes:
-    label: Have you checked the wiki for solutions?
-    description: |
-      Please check the wiki to see if your issue is addressed: https://github.com/canonical/steam-snap/wiki. If you do any troubleshooting from the wiki, please include it in the final section of this report.
-    options:
-    - label: I have searched the wiki
-      required: true
-- type: checkboxes
-  attributes:
-    label: Is this a Steam Snap-specific issue?
-    description: |
-      Please make sure your issue is exclusive to the Steam Snap and doesn't occur in the Steam deb. If this is a deb issue, then open an issue in Valve's repository instead: https://github.com/ValveSoftware/steam-for-linux. If you don't know or don't use the deb version of Steam, leave this unchecked.
-    options:
-    - label: This is a Steam Snap-specific issue
-      required: false
 - type: textarea
   attributes:
     label: Current Behavior
@@ -62,7 +50,7 @@ body:
   attributes:
     label: Environment
     description: |
-      Output of `snap run steam.report`. More info on this command [here](https://github.com/canonical/steam-snap/wiki/Troubleshooting#submitting-a-steam-report).
+      Run `snap run steam.report` in a terminal or right-click Steam and choose "Report", then paste the output here. More info on this command [here](https://github.com/canonical/steam-snap/wiki/Troubleshooting#submitting-a-steam-report).
     placeholder: |
       os_release:
           name:
@@ -104,6 +92,8 @@ body:
       Screenshots? [Logs](https://github.com/canonical/steam-snap/wiki/Troubleshooting#view-logs)? Links? Anything that will give us more context about the issue. If pasting logs, please format them by surrounding the text with ```.
 
       Please include [Steam logs](https://github.com/canonical/steam-snap/wiki/Troubleshooting#view-logs) (if applicable) and any additional steps you took to troubleshoot. For troubleshooting ideas, see the [wiki](https://github.com/canonical/steam-snap/wiki).
+
+      If you are able, please include whether the issue occurs on the Steam deb as well as the Snap.
 
       Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
   validations:

--- a/.github/ISSUE_TEMPLATE/feature_reqest.yml
+++ b/.github/ISSUE_TEMPLATE/feature_reqest.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest an idea for this project
 title: "<title>"
-labels: [enhancement]
+labels: [type/enhancement]
 body:
 - type: checkboxes
   attributes:


### PR DESCRIPTION
Since we restructured the bug and enhancement labels to be `type/bug` and `type/enhancement` respectively, the issue template auto labeling became broken, so this PR fixes that.

In addition, the bug issue template has been slimmed down a little bit to reduce friction and provide clearer direction to openers.

You can view what these templates look like by opening an issue in my repository: https://github.com/ashuntu/steam-snap/issues/new/choose.

UDENG-1869