### PR TITLE
Remove libdrm bind

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,8 +38,6 @@ layout:
   /usr/share/zenity:
     bind: $SNAP/usr/share/zenity
   # https://discourse.ubuntu.com/t/the-graphics-core20-snap-interface/23000
-  /usr/share/libdrm/amdgpu.ids:
-    bind-file: $SNAP/graphics/usr/share/libdrm/amdgpu.ids
   /usr/share/drirc.d:
     bind: $SNAP/graphics/usr/share/drirc.d
   /usr/share/glvnd/egl_vendor.d:


### PR DESCRIPTION
Removes the bind for `libdrm`/`amdgpu.ids` entirely. It seems like that file is automatically created and has the same contents as `$SNAP/graphics/usr/share/libdrm` anyway. The bind was previously tested, but it seems to just lead to an empty file now.

When testing, please make sure that `/usr/share/libdrm/amdgpu.ids` is populated and has the same content as `$SNAP/graphics/usr/share/libdrm/amdgpu.ids` from within the Steam snap shell. You should also *not* see errors related to missing `amdgpu.ids` when running Steam and games.

Related, and *possibly* a fix for: https://github.com/canonical/steam-snap/issues/348