### PR TITLE
fix: Remove duplicate staged paths

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -144,7 +144,6 @@ parts:
       - usr/lib/**/gtk-3.0*
       - etc/gtk-3.0*
       - usr/share/*/gir1.2-gtk-3.0*
-      - usr/share/*/libgtk-3*
       - usr/**/libfontconfig*
       - usr/**/cairo-1*
       - usr/**/libatspi*
@@ -158,7 +157,6 @@ parts:
       - usr/**/libdconf*
       - usr/**/libdeflate*
       - usr/**/libepoxy*
-      - usr/**/libfontconfig*
       - usr/**/libfribidi*
       - usr/**/*girepository*
       - usr/**/libgraphite2*


### PR DESCRIPTION
Very small PR that just removes 2 duplicate paths from staging.

`usr/**/libfontconfig*` was a direct duplicate. `usr/share/*/libgtk-3*` was a duplicate since `usr/**/libgtk-3*` already overlaps that path.