### PR TITLE
fix: Update snapd assumes to 2.61.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ architectures:
 base: core22
 compression: lzo
 assumes:
-  - snapd2.55.4
+  - snapd2.62
 
 lint:
   # Snapcraft's `ldd` lint can't handle 32-bit things,


### PR DESCRIPTION
Updates the required snapd version for Steam to 2.61.1 (latest) from 2.55.4. This may need to change if the latest snapd version is different when the pressure vessel changes land in snapd, so this is a draft for now.

---

UDENG-2293