### PR TITLE
ci: add workflow dispatch build action trigger

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   snap:


### PR DESCRIPTION
currently, if the build test fails in ci, there is no way to retrigger the test unless commiting to the source branch
this adds the workflow dispatch parameter to allow the job to re-run