### PR TITLE
fix: Use correct MangoHUD path on 32-bit games

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -284,10 +284,11 @@ parts:
       - libwayland-dev
       - libxkbcommon-dev:i386
       - libxkbcommon-dev
-    # Fixes the $LIB being escaped for some reason
+    stage-packages:
+      - libxkbcommon0:i386
     override-build: |
         craftctl default
-        sed -i 's/\/usr\/\\\$LIB/\$SNAP\/usr\/lib\/x86_64-linux-gnu/' $CRAFT_PART_INSTALL/usr/bin/mangohud
+        sed -i 's/\/usr\/\\\$LIB/\$SNAP\/usr\/\\\$LIB/' $CRAFT_PART_INSTALL/usr/bin/mangohud
 
   mangohud64:
     after: [meson-deps, mangohud]


### PR DESCRIPTION
There was no way previously for MangoHUD to work if it required the 32-bit versions if its libraries due to our replacing of the dynamic linker's `$LIB`. This PR fixes that and corrects the path to the libraries located in `$SNAP`.