### PR TITLE
Links to GTK configuration files and fix icons and shortcuts

### DIFF
--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -335,13 +335,27 @@ done
 
 # Links game icons to host
 find "$SNAP_USER_COMMON/.local/share/icons/hicolor" -type f -name "steam_icon_*.png" | while read -r file; do
-  dest="${file/$SNAP_USER_COMMON/$REALHOME}"
+  dest="${file/$SNAP_USER_COMMON/$SNAP_REAL_HOME}"
   ensure_dir_exists "$(dirname $dest)"
   ln -sf "$file" "$dest"
 done
 
 # Link .desktop files to host
-ln -sf $SNAP_USER_COMMON/.local/share/applications/* $REALHOME/.local/share/applications/
+ln -f $SNAP_USER_COMMON/.local/share/applications/* $SNAP_REAL_HOME/.local/share/applications/
+
+# Link .desktop files to $SNAP_REAL_HOME
+ln -f $SNAP_USER_COMMON/Desktop/* $SNAP_REAL_HOME/
+
+# GTK theme and behavior modifier
+# Those can impact the theme engine used by Qt as well
+gtk_configs=(gtk-4.0/settings.ini gtk-4.0/gtk.css gtk-4.0/bookmarks gtk-4.0/colors.css gtk-3.0/settings.ini gtk-3.0/gtk.css gtk-3.0/bookmarks gtk-3.0/colors.css gtk-2.0/gtkfilechooser.ini)
+for f in "${gtk_configs[@]}"; do
+  dest="$XDG_CONFIG_HOME/$f"
+  if [ ! -L "$dest" ]; then
+    ensure_dir_exists "$(dirname "$dest")"
+    ln -s "$SNAP_REAL_HOME/.config/$f" "$dest"
+  fi
+done
 
 strip_unreachable_dirs XDG_DATA_DIRS
 strip_unreachable_dirs XDG_CONFIG_DIRS


### PR DESCRIPTION
I made some changes to alleviate the cursor shifting issue when using Steam.
This part of the code was taken from the snapcraft-desktop-integration repository; I just added support for the gtk-4.0 folder for good measure.
https://github.com/canonical/steam-snap/issues/444

I also tweaked the creation of shortcut links to the menu, as well as the icons used by it.
https://github.com/canonical/steam-snap/issues/446
https://github.com/canonical/steam-snap/issues/421

Since the shortcut links to the Desktop folder are proving more difficult to get working, I moved them to the $HOME folder, where they're visible enough to the user. It's a workaround, but I suppose it's useful.
https://github.com/canonical/steam-snap/issues/421

In this case, the file I'm modifying, which is used in Steam Snap, copies these files when Steam is reopened, so if you try this change, keep that in mind.

If you're curious about why the command ```ln -sf``` was changed to just ```ln -f``` it's so that the shortcut doesn't look like a link, as the shortcuts generated by Steam are not links, they are ```.desktop``` files.