### PR TITLE
Remove links in the applications folder that open the applications folder itself.

### DIFF
--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -364,6 +364,9 @@ ln -sf "$DESKTOP_PATH" "$SNAP_USER_COMMON/Desktop"
 ln -sf $SNAP_REAL_HOME/.local/share/applications/ $SNAP_USER_COMMON/.local/share/applications
 ln -sf $SNAP_REAL_HOME/.local/share/icons/ $SNAP_USER_COMMON/.local/share/icons
 
+# Remove links from the user's applications folder that open the applications folder itself.
+find "$SNAP_REAL_HOME/.local/share/applications/" -type l -lname "$SNAP_REAL_HOME/.local/share/applications" -delete
+
 # GTK theme and behavior modifier
 # Those can impact the theme engine used by Qt as well
 gtk_configs=(gtk-4.0/settings.ini gtk-4.0/gtk.css gtk-4.0/bookmarks gtk-4.0/colors.css gtk-3.0/settings.ini gtk-3.0/gtk.css gtk-3.0/bookmarks gtk-3.0/colors.css gtk-2.0/gtkfilechooser.ini)


### PR DESCRIPTION
This is only to fix the .desktop files that were being multiplied in the applications menu.

Related https://github.com/canonical/steam-snap/pull/451

---

UDENG-8545