### PR TITLE
fix: Correct issue template references to gaming-graphics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,11 +72,11 @@ body:
     required: true
 - type: dropdown
   attributes:
-    label: gaming-graphics-core22 version
+    label: gaming-graphics-core24 version
     description: |
-      Please select the version(s) of the [gaming-graphics-core22](https://github.com/canonical/gaming-graphics/) Snap you have tried/this issue affects. More info on this [here](https://github.com/canonical/steam-snap/wiki/FAQ#how-do-i-use-a-different-mesagraphics-version).
+      Please select the version(s) of the [gaming-graphics-core24](https://github.com/canonical/gaming-graphics/) Snap you have tried/this issue affects. More info on this [here](https://github.com/canonical/steam-snap/wiki/FAQ#how-do-i-use-a-different-mesagraphics-version).
 
-      If the issue is graphics/GPU related, it is very useful to us if you try each gaming-graphics-core22 branch and report observed behavior differences.
+      If the issue is graphics/GPU related, it is very useful to us if you try each gaming-graphics-core24 branch and report observed behavior differences.
     options:
       - kisak-fresh (default)
       - kisak-turtle


### PR DESCRIPTION
Rename references to `gaming-graphics-core22` to `gaming-graphics-core24`.

---

UDENG-8943