### PR TITLE
fix: use ln -snf to prevent recursive symlinks in applications dir

### DIFF
--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -360,9 +360,9 @@ rm -r $SNAP_USER_COMMON/Desktop
 rm -r $SNAP_USER_COMMON/.local/share/applications
 rm -r $SNAP_USER_COMMON/.local/share/icons
 
-ln -sf "$DESKTOP_PATH" "$SNAP_USER_COMMON/Desktop"
-ln -sf $SNAP_REAL_HOME/.local/share/applications/ $SNAP_USER_COMMON/.local/share/applications
-ln -sf $SNAP_REAL_HOME/.local/share/icons/ $SNAP_USER_COMMON/.local/share/icons
+ln -snf "$DESKTOP_PATH" "$SNAP_USER_COMMON/Desktop"
+ln -snf $SNAP_REAL_HOME/.local/share/applications/ $SNAP_USER_COMMON/.local/share/applications
+ln -snf $SNAP_REAL_HOME/.local/share/icons/ $SNAP_USER_COMMON/.local/share/icons
 
 # Remove links from the user's applications folder that open the applications folder itself.
 find "$SNAP_REAL_HOME/.local/share/applications/" -type l -lname "$SNAP_REAL_HOME/.local/share/applications" -delete


### PR DESCRIPTION
## Summary

- Replace `ln -sf` with `ln -snf` on lines 363-365 of `desktop-launch` to prevent recursive symlinks when `rm -r` fails silently during snap refresh race conditions

## Problem

When the `rm -r` on lines 359-361 fails silently (no `set -e`), `ln -sf` follows the existing symlink-to-directory and creates the new link **inside** the target directory. This results in:

```
~/.local/share/applications/applications -> ~/.local/share/applications/
```

GNOME Shell's app indexer follows this recursive symlink, causing every `.desktop` file to appear multiple times in the app launcher/search.

## Fix

`ln -snf` treats a symlink-to-directory as a symlink (via `-n` flag) rather than following it, so it gets replaced in place. This is the standard idiom for atomically updating symlinks that may point to directories.

Note: line 368 already has a `find -delete` cleanup for this exact symptom, which confirms this has been an issue before. With `-snf` the cleanup is no longer needed, but I've left it in place as a safety net.

Fixes #490

## Test plan

- [ ] Verify `ln -snf` correctly replaces existing symlink-to-directory without following it
- [ ] Verify Steam launches normally after the change
- [ ] Verify no recursive symlink is created in `~/.local/share/applications/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)