### PR TITLE
docs: structure side navigation for contributing

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -2,19 +2,45 @@
 myst:
   html_meta:
     "description lang=en":
-      "Help us test the Steam snap on Ubuntu."
+      "Help us develop the Steam snap on Ubuntu."
 ---
 
+<<<<<<<< HEAD:docs/howto/test-steam-snap.md
 (howto::test-steam-snap)=
 # Test the Steam snap on your machine
+========
+(contribute::development)=
+# Development
+>>>>>>>> 7027b49 (expand testing guide into dev guide):docs/contributing/development.md
 
-```{note}
-This testing procedure is generally for internal use.
+## Building
+
+Building the Steam snap locally requires
+[Snapcraft](https://docs.snapcraft.io/snapcraft-overview).
+
+To build the snap, run the following command:
+
+```shell
+snapcraft --use-lxd
 ```
+
+Then install it with:
+
+```shell
+snap install steam.snap --dangerous
+```
+
+To run:
+
+```shell
+snap run steam
+```
+
+## Testing
 
 The following steps assume you have successfully created a `steam_*.snap` with
 `snapcraft` and installed it with `snap install steam_*.snap --dangerous`. This
-also assumes you have Steam Play (Proton) enabled for any game.
+also assumes you have Steam Play  enabled for any game.
 
 Repeat the below steps on every combination of GPUs possible on your system.
 On hybrid systems, try in hybrid mode (both cards on and available) and
@@ -23,7 +49,7 @@ dedicated GPU modes (single card on and available).
 See the page on {ref}`using a dedicated GPU <howto::dedicated-gpu>` for tips on
 switching graphics cards.
 
-## Minimum steps
+### Minimum steps
 
 - Run `snap run steam.test`. Ensure GLX and Vulkan both report "passed".
 - Run `snap run steam.report --no-submit`. Ensure that no error occurs and each
@@ -32,7 +58,7 @@ switching graphics cards.
   tab (Store, Library, etc.) populates correctly with content.
 - Run some games. Ensure they open and can be played.
 
-## Additional suggested steps
+### Additional suggested steps
 
 - Run each game listed in the {ref}`Suggested Games <howto::suggested-games>`
   section. At a minimum, choose 1 Native game and 1 Proton game. Check that the
@@ -53,7 +79,7 @@ switching graphics cards.
 - Plug in a supported controller (PS4, Xbox One and Xbox 360 controllers) and
   make sure the input is processed in the games.
 
-## Additional optional steps
+### Additional optional steps
 
 - Run each game listed in the {ref}`Additional Games <howto::additional-games>` section.
     - Opens correctly to main menu
@@ -81,7 +107,7 @@ characters into the Steam client.
       [here](https://github.com/flightlessmango/MangoHud/issues/369). The game
       should run, however.
 
-## Free games to test
+### Free games to test
 
 The following is a list of *free* games using various engines and varying Linux support.
 
@@ -89,7 +115,7 @@ If you cannot run every game in a list, prioritize games in top-down order and
 ensure you use both a Proton and a Native game.
 
 (howto::suggested-games)=
-### Suggested games
+#### Suggested games
 
 *These games are generally small in scope and size.*
 
@@ -109,7 +135,7 @@ ensure you use both a Proton and a Native game.
 <!-- | - | Proton | Source | - | -->
 
 (howto::additional-games)=
-### Additional games
+#### Additional games
 
 *These games are generally large in scope and size.*
 
@@ -122,7 +148,7 @@ ensure you use both a Proton and a Native game.
 <!-- | - | - | Unreal | - | -->
 <!-- | - | - | Godot | - | -->
 
-### Collections
+#### Collections
 
 Steam game collections can be a useful feature for keeping track of well-tested games. Follow these steps to create a *Dynamic Collection* that automatically populates with games based on Steam Deck status:
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -5,13 +5,8 @@ myst:
       "Help us develop the Steam snap on Ubuntu."
 ---
 
-<<<<<<<< HEAD:docs/howto/test-steam-snap.md
-(howto::test-steam-snap)=
-# Test the Steam snap on your machine
-========
 (contribute::development)=
 # Development
->>>>>>>> 7027b49 (expand testing guide into dev guide):docs/contributing/development.md
 
 ## Building
 

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -1,0 +1,104 @@
+---
+myst:
+  html_meta:
+    "description lang=en":
+      "Help us document the Steam snap on Ubuntu."
+---
+
+(contribute::documentation)=
+# Documentation
+
+This guide provides information necessary to contribute to this documentation.
+If you're contributing for the first time, you might find the Canonical Open
+Documentation Academy has helpful resources to
+[get you started](https://documentation.academy/docs/howto/get-started/).
+
+## Report an issue
+
+To report a mistake on any page, or highlight some missing documentation,
+[file an issue](https://github.com/canonical/steam-snap) in our
+issues list on GitHub.
+
+You can do this using the {guilabel}`Give feedback` button on any page, which will open a
+new issue.
+
+Make sure to provide enough information in the issue for us to understand what
+is needed.
+
+## Contribute on GitHub
+
+If you are familiar with a Git development workflow, `fork` the
+[Steam snap repository](https://github.com/canonical/steam snap)
+and contribute your change as a
+[pull request](https://github.com/canonical/steam-snap/pulls).
+
+### Directory structure
+
+All the documentation files are located in the `docs/` directory. The `docs/`
+directory contains sub-directories according to the type of content.
+
+All content is written and split according to the principles of
+[Diátaxis](https://diataxis.fr/). It is then organized for our readers
+according to who is using it, and how.
+
+## Build the documentation locally
+
+Follow these steps to build the documentation on your local machine.
+
+### Prerequisites
+
+* Git
+* The `make` tool
+
+    ```{note}
+    The `make` command is compatible with Unix systems. On Windows,
+    [install Ubuntu with WSL](https://documentation.academy/docs/howto/get-started/using_wsl/).
+    ```
+
+### Procedure
+
+1. Fork the [Steam snap repository](https://github.com/canonical/steam-snap). Visit [Fork a repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) for instructions.
+
+2. Clone the repository to your machine:
+    ```none
+    git clone git@github.com:<your_user_name>/steam-snap.git
+    ```
+
+3. Create a new branch:
+    ```none
+    git checkout -b <your_branch_name>
+    ```
+
+4. Change to the `docs/` directory and make your contribution:
+    ```none
+    cd docs
+    ```
+
+5. Build a live preview of the documentation from within the `docs/` directory:
+    ```none
+    make run
+    ```
+    You can find all the HTML files in the `.build/` directory.
+
+    `make run` uses the Sphinx `autobuild` module, so that any edits you make (and save) as you work are applied, and the built HTML files refresh immediately.
+
+6. Review your contribution in a web browser by navigating to [`127.0.0.1:8000`](http://127.0.0.1:8000/).
+
+7. Push your contribution to GitHub and create a pull request against the original repository.
+
+## Documentation format
+
+The Steam on Ubuntu documentation is built with Sphinx using a combination of the MyST flavor of the Markdown.
+
+* [MyST style guide](https://canonical-starter-pack.readthedocs-hosted.com/stable/reference/myst-syntax-reference/)
+
+## Testing the documentation
+
+Test your changes before submitting a pull request. Run the following commands from within the `docs/` directory to test the documentation locally:
+
+| command  | use |
+|---------|-----|
+| `make spelling` | Check for spelling errors |
+| `make linkcheck` | Check for broken links |
+| `make woke` | Check for non-inclusive language |
+| `make pa11y` | Check for accessibility issues |

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ Ubuntu.
 * **Troubleshooting**: {ref}`Troubleshoot common issues <howto::troubleshooting>` • {ref}`Find game-specific workarounds <howto::game-workarounds>`
 * **Reference**: {ref}`Glossary <reference::glossary>` • {ref}`Locations for external libraries <reference::external-libraries>`
 * **Additional information**: {ref}`Snap vs. deb comparison <explanation::snap-versus-deb>` • {ref}`Testing the Steam snap <howto::test-steam-snap>`
+* **Additional information**: [Snap vs deb comparison](/explanation/snap-versus-deb) • {ref}`What games can I play? <explanation::what-games-can-i-play>`
 
 ## How the documentation is organised
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,3 +52,11 @@ How-to guides </howto/index>
 Reference </reference/index>
 Explanation </explanation/index>
 ```
+```{toctree}
+:caption: Contributing
+:hidden:
+
+contributing/development
+contributing/documentation
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,6 @@ Ubuntu.
 * **Graphics and performance**: {ref}`Use your dedicated GPU <howto::dedicated-gpu>` • {ref}`Change mesa/graphics version <howto::change-mesa-graphics>` • {ref}`Configure MangoHud <howto::configure-mangohud>`
 * **Troubleshooting**: {ref}`Troubleshoot common issues <howto::troubleshooting>` • {ref}`Find game-specific workarounds <howto::game-workarounds>`
 * **Reference**: {ref}`Glossary <reference::glossary>` • {ref}`Locations for external libraries <reference::external-libraries>`
-* **Additional information**: {ref}`Snap vs. deb comparison <explanation::snap-versus-deb>` • {ref}`Testing the Steam snap <howto::test-steam-snap>`
 * **Additional information**: [Snap vs deb comparison](/explanation/snap-versus-deb) • {ref}`What games can I play? <explanation::what-games-can-i-play>`
 
 ## How the documentation is organised


### PR DESCRIPTION
Main changes:

- Structures the side nav to have a dedicated Contributing section.
- Expands the testing guide into a dev guide.
- Adds docs contribution guide

<img width="1090" height="550" alt="Screenshot From 2026-04-28 11-58-28" src="https://github.com/user-attachments/assets/5763b285-f88a-48a0-9d70-9317fd4e29a6" />
