### PR TITLE
docs: Reduce glossary term density

### DIFF
--- a/docs/explanation/what-games-can-i-play.md
+++ b/docs/explanation/what-games-can-i-play.md
@@ -21,7 +21,7 @@ to work on desktop Linux distributions.
 
 ## Filtering your game library
 
-To filter your own library by *{term}`Steam Deck` Verification*,
+To filter your own library by *Steam Deck Verification*,
 go to your Steam {guilabel}`Library` tab and click the penguin
 ([Tux](https://en.wikipedia.org/wiki/Tux_(mascot))) to show games that run on
 Linux. 

--- a/docs/howto/configure-mangohud.md
+++ b/docs/howto/configure-mangohud.md
@@ -19,7 +19,7 @@ It is bundled with the Steam {term}`snap` and disabled by default.
 {term}`MangoHud` support is experimental and will likely only work with **OpenGL**
 games. 
 
-Please do not open issues relating solely to {term}`MangoHud` compatibility.
+Please do not open issues relating solely to MangoHud compatibility.
 ```
 
 ## Enable MangoHud
@@ -55,10 +55,10 @@ MANGOHUD_CONFIG=time mangohud %command%
 To use MangoHud's config file:
 
 1. Run `snap run --shell steam`
-2. Make the {term}`MangoHud` config directory: `mkdir -p ~/.config/MangoHud`
+2. Make the MangoHud config directory: `mkdir -p ~/.config/MangoHud`
 3. Copy the default config file: `cp $SNAP/usr/share/doc/mangohud/MangoHud.conf.example ~/.config/MangoHud/MangoHud.conf`
 4. Edit `~/.config/MangoHud/MangoHud.conf` to your liking
-5. Run {term}`MangoHud` like usual
+5. Run MangoHud like usual
 
 ```{seealso}
 [Configuration](https://github.com/flightlessmango/MangoHud#hud-configuration) in the MangoHud documentation.

--- a/docs/howto/configure-proton.md
+++ b/docs/howto/configure-proton.md
@@ -19,20 +19,20 @@ Proton, it is native and likely works the best without Proton.
 
 [ProtonDB](https://www.protondb.com/), a crowdsourced database of compatibility information, will show "Native" if the game is a {term}`native game`. Otherwise, it requires Proton.
 
-Disabling {term}`Steam Play` entirely will only then allow you to install and play {term}`native games <native game>`.
+Disabling Steam Play entirely will only then allow you to install and play native games.
 
 ## Enable Proton for non-native games
 
 In the Steam application, navigate to {guilabel}`Settings` > {guilabel}`Steam Play`
 
-Enabling {term}`Steam Play` will automatically download the {term}`Proton` {term}`compatibility layer` libraries
-for non-native games. If left disabled, only {term}`native games <native game>` can be installed and
+Enabling Steam Play will automatically download the Proton {term}`compatibility layer` libraries
+for non-native games. If left disabled, only native games can be installed and
 played.
 
-"Enable Steam Play for supported titles" enables {term}`compatibility layer` tools for games
+"Enable Steam Play for supported titles" enables compatibility layer tools for games
 verified by Valve to work well on Linux.
 
-"Enable Steam Play for all other titles" enables {term}`compatibility layer` tools for *all*
+"Enable Steam Play for all other titles" enables compatibility layer tools for *all*
 non-native games in your library. 
 
 Unsupported titles greatly vary in functionality -- check {term}`ProtonDB` for more info on specific games.
@@ -55,9 +55,9 @@ Create the `compatibilitytools.d` directory:
 mkdir -p ~/snap/steam/common/.steam/root/compatibilitytools.d
 ```
 
-Extract custom {term}`Proton` versions to the above directory. For example, [proton-ge](https://github.com/GloriousEggroll/proton-ge-custom).
+Extract custom Proton versions to the above directory. For example, [proton-ge](https://github.com/GloriousEggroll/proton-ge-custom).
 
-Run Steam, and you should be able to select your custom version from the {term}`Proton` version dropdown like normal.
+Run Steam, and you should be able to select your custom version from the Proton version dropdown like normal.
 
 ```{seealso}
 [Original `proton-ge-custom` instructions](https://github.com/GloriousEggroll/proton-ge-custom#snap)

--- a/docs/howto/install.md
+++ b/docs/howto/install.md
@@ -59,7 +59,7 @@ snap connect steam:hardware-observe
 snap connect steam:audio-record
 ```
 
-For more information on the {term}`snap connections <snap connection>`, run
+For more information on the snap connections, run
 
 ```shell
 snap connections steam

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ myst:
 
 Valve's [Steam](https://store.steampowered.com/about/) client is available to Ubuntu users as a {term}`snap`.
 
-The Steam {term}`snap` provides a consistent environment to run games. The
+The Steam snap provides a consistent environment to run games. The
 environment is separate from the underlying host operating system and receives
 automatic updates. It also comes bundled with useful tools, like
 {term}`MangoHud`.


### PR DESCRIPTION
Generally, we try to reference the glossary on the first usage of a term in given page and avoid referencing the glossary entry for that term thereafter, top avoid noise.