### PR TITLE
docs: add more prominent snap links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Steam Snap
 
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/steam)
+
 This is a snap of Valve's [Steam client][1]. It is intended to run on any system that supports snapd, providing a consistent environment to
 run the games separate from the underlying host operating system.
 

--- a/docs/.sphinx/_static/css/snap-badge.css
+++ b/docs/.sphinx/_static/css/snap-badge.css
@@ -1,0 +1,7 @@
+.snap-store-badge-container {
+    padding: 1rem 0 1rem var(--toc-spacing-horizontal);
+}
+.snap-badge {
+    width: 100%;
+    max-width: 182px;
+}

--- a/docs/.sphinx/_templates/page.html
+++ b/docs/.sphinx/_templates/page.html
@@ -1,0 +1,61 @@
+{% extends "furo/page.html" %}
+
+{% block footer %}
+   {% include "footer.html" %}
+{% endblock footer %}
+
+{% block body -%}
+   {% include "header.html" %}
+   {{ super() }}
+{%- endblock body %}
+
+{% if meta and ((meta.discourse and discourse_prefix) or meta.relatedlinks) %}
+   {% set furo_hide_toc_orig = furo_hide_toc %}
+   {% set furo_hide_toc=false %}
+{% endif %}
+
+{% block right_sidebar %}
+<div class="toc-sticky toc-scroll">
+   {% if not furo_hide_toc_orig %}
+    <div class="toc-title-container">
+      <span class="toc-title">
+       {{ _("Contents") }}
+      </span>
+    </div>
+    <div class="toc-tree-container">
+      <div class="toc-tree">
+        {{ toc }}
+      </div>
+    </div>
+   {% endif %}
+    {% if meta and ((meta.discourse and discourse_prefix) or meta.relatedlinks) %}
+    <div class="relatedlinks-title-container">
+      <span class="relatedlinks-title">
+       Related links
+      </span>
+    </div>
+    <div class="relatedlinks-container">
+      <div class="relatedlinks">
+        {% if meta.discourse and discourse_prefix %}
+          {{ discourse_links(meta.discourse) }}
+        {% endif %}
+        {% if meta.relatedlinks %}
+          {{ related_links(meta.relatedlinks) }}
+        {% endif %}
+      </div>
+    </div>
+    {% endif %}
+    {% if pagename == "index" %}
+    <div class="snap-store-badge-container">
+      <a href="https://snapcraft.io/steam" target="_blank" rel="noopener">
+        <img class="snap-badge only-light"
+             src="https://snapcraft.io/static/images/badges/en/snap-store-white.svg"
+             alt="Get it from the Snap Store" />
+        <img class="snap-badge only-dark"
+             src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg"
+             alt="Get it from the Snap Store" />
+      </a>
+    </div>
+    {% endif %}
+  </div>
+{% endblock right_sidebar %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -210,7 +210,7 @@ sitemap_excludes = [
 #######################
 
 html_static_path = [".sphinx/_static"]
-#templates_path = ["_templates"]
+templates_path = [".sphinx/_templates"]
 
 
 #############
@@ -300,7 +300,7 @@ exclude_patterns = [
 
 # Adds custom CSS files, located under 'html_static_path'
 
-html_css_files = ["css/dropdown.css"]
+html_css_files = ["css/dropdown.css", "css/snap-badge.css"]
 
 # Adds custom JavaScript files, located under 'html_static_path'
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,15 +8,14 @@ myst:
 
 # Steam on Ubuntu
 
-Valve's [Steam](https://store.steampowered.com/about/) client is available to Ubuntu users as a {term}`snap`.
+Valve's Steam client is available to Ubuntu users as a snap.
 
 The Steam snap provides a consistent environment to run games. The
 environment is separate from the underlying host operating system and receives
 automatic updates. It also comes bundled with useful tools, like
-{term}`MangoHud`.
+MangoHud.
 
-The snap can be run on any system that supports {term}`snapd`, including
-Ubuntu.
+The snap can be run on any system that supports snapd, including Ubuntu.
 
 ## In this documentation
 


### PR DESCRIPTION
For a user who lands on the README or the docs, it is not obvious where to actually get the Steam snap.

This adds a Snap Store badge to both the README and the docs. Note, the badge only appears in the homepage of the docs.

Light- and dark-specific badges are used for the docs. I couldn't get this working for the README, as I believe it only works for local images in repos and that seemed to be the case during my tests.

One additional change is the removal of in-line links in the main homepage text. There are already a lot of links on the homepage, so we probably don't need them. If someone is unclear about a term it's an invitation to continue reading or find information in the docs.

<img width="1468" height="1108" alt="image" src="https://github.com/user-attachments/assets/fd93406d-8a00-44e9-adaa-e7274fdf9ae7" />

<img width="1460" height="1079" alt="image" src="https://github.com/user-attachments/assets/54dc5661-7a83-436c-b07f-b0801d243b88" />
