### PR TITLE
Steamlink fix

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,8 @@ layout:
     bind: $SNAP/usr/lib/x86_64-linux-gnu/alsa-lib
   /usr/share/alsa:
     bind: $SNAP/usr/share/alsa
+  /usr/share/pipewire:
+    bind: $SNAP/usr/share/pipewire
   /usr/share/X11/xkb:
     bind: $SNAP/usr/share/X11/xkb
   /usr/lib/x86_64-linux-gnu/libvulkan_intel.so:
@@ -425,8 +427,11 @@ parts:
       - libxrandr2:i386
       - libxi6:amd64
       - libxi6:i386
+      - pipewire
       - libpipewire-0.3-0t64:amd64
       - libpipewire-0.3-0t64:i386
+      - libpipewire-0.3-modules:amd64
+      - libpipewire-0.3-modules:i386
       - libopenal1:amd64
       - libopenal1:i386
       - libpulse0:amd64

--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -286,6 +286,11 @@ if [ -n "$XDG_RUNTIME_DIR" ]; then
     fi
 fi
 
+# Tell Pipewire where to find its configuration and plugins
+export PIPEWIRE_CONFIG_DIR="$SNAP_DESKTOP_RUNTIME/usr/share/pipewire"
+export PIPEWIRE_MODULE_DIR="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/pipewire-0.3"
+export SPA_PLUGIN_DIR="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/spa-0.2"
+
 # Keep an array of data dirs, for looping through them
 IFS=':' read -r -a data_dirs_array <<< "$XDG_DATA_DIRS"
 


### PR DESCRIPTION
Fixes #502 

pw_loop_new returns nullptr because it can't find libspa-support.so and steam passes the nullptr to pw_thread_loop_start
[Putting this in desktop-launch was enough to make my phone connect to my desktop](https://github.com/canonical/snapcraft-desktop-integration/blob/main/common/desktop-exports#L134)

desktop - desktop connection does something different (requires -pipewire arg to even work) and will still crash steam, now it fails to create pipewire context because it can't find client.conf from pipewire package, and then it fails to load i386 modules. 
Adding pipewire and i386 modules package to stage-packages fixes it.

At this point steamlink works, and is just as bad as .deb version on wayland. One thing that does happen in the snap after all this but doesn't on deb is that steam complains about lack of i386 dri_gbm.so, I think mesa snap package installs libgbm1 but i386 is not there, even after putting it in the steam snap it still throws:
```
CDesktopCapturePipeWire: Opening DRM render node /dev/dri/renderD128
CDesktopCapturePipeWire: Couldn't create EGL display: 0x300c
```
And I have no idea how to fix it, but steam link works so I just left it at this point.