### PR TITLE
fix: Glob Vulkan icd files

### DIFF
--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -109,6 +109,15 @@ function append_dir() {
   fi
 }
 
+function append_file() {
+  local -n var="$1"
+  local file="$2"
+  # We can't check if the file exists when the path contains variables
+  if [[ "$file" == *"\$"*  || -e "$file" ]]; then
+    export "${!var}=${var:+$var:}${file}"
+  fi
+}
+
 
 function strip_unreachable_dirs() {
   local -n var=$1
@@ -186,7 +195,12 @@ if [ -e "/var/lib/snapd/lib/gl/vdpau/libvdpau_nvidia.so" ]; then
 fi
 
 # Export Vulkan ICD filename paths
-export VK_ICD_FILENAMES="/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/graphics/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:$SNAP/graphics/usr/share/vulkan/icd.d/radeon_icd.i686.json:$SNAP/graphics/usr/share/vulkan/icd.d/intel_icd.x86_64.json:$SNAP/graphics/usr/share/vulkan/icd.d/intel_icd.i686.json"
+unset VK_ICD_FILENAMES
+append_file VK_ICD_FILENAMES "/var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json"
+for _f in "$SNAP"/graphics/usr/share/vulkan/icd.d/*_icd*.json; do
+  append_file VK_ICD_FILENAMES "$_f"
+done
+unset _f
 
 # Workaround in snapd for proprietary nVidia drivers mounts the drivers in
 # /var/lib/snapd/lib/gl that needs to be in LD_LIBRARY_PATH


### PR DESCRIPTION
Some different versions of the graphics libraries provide arch-specific json files, while others are arch agnostic. This breaks games since the arch-specific icds are not longer present in VK_ICD_FILENAMES.

This should account for both the arch-agnostic files as well as well as the arch-specific ones.

Example output using `kisak-fresh/candidate`: 
```
$ echo $VK_ICD_FILENAMES
/snap/steam/x2/graphics/usr/share/vulkan/icd.d/asahi_icd.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/dzn_icd.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/freedreno_icd.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/gfxstream_vk_icd.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/intel_hasvk_icd.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/intel_icd.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/lvp_icd.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/nouveau_icd.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/radeon_icd.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/virtio_icd.json
```

Example output using `kisak-fresh/stable`:
```
$ echo $VK_ICD_FILENAMES
/snap/steam/x2/graphics/usr/share/vulkan/icd.d/asahi_icd.i686.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/asahi_icd.x86_64.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/dzn_icd.x86_64.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/freedreno_icd.i686.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/freedreno_icd.x86_64.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/gfxstream_vk_icd.x86_64.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/intel_hasvk_icd.i686.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/intel_hasvk_icd.x86_64.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/intel_icd.i686.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/intel_icd.x86_64.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/lvp_icd.i686.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/lvp_icd.x86_64.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/nouveau_icd.x86_64.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/radeon_icd.i686.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/virtio_icd.i686.json:/snap/steam/x2/graphics/usr/share/vulkan/icd.d/virtio_icd.x86_64.json
```