### PR TITLE
feat: Upgrade to core26

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,11 +72,11 @@ body:
     required: true
 - type: dropdown
   attributes:
-    label: gaming-graphics-core24 version
+    label: gaming-graphics-core26 version
     description: |
-      Please select the version(s) of the [gaming-graphics-core24](https://github.com/canonical/gaming-graphics/) Snap you have tried/this issue affects. More info on this [here](https://ubuntu.com/docs/steam/howto/change-mesa-graphics/).
+      Please select the version(s) of the [gaming-graphics-core26](https://github.com/canonical/gaming-graphics/) Snap you have tried/this issue affects. More info on this [here](https://ubuntu.com/docs/steam/howto/change-mesa-graphics/).
 
-      If the issue is graphics/GPU related, it is very useful to us if you try each gaming-graphics-core24 branch and report observed behavior differences.
+      If the issue is graphics/GPU related, it is very useful to us if you try each gaming-graphics-core26 branch and report observed behavior differences.
     options:
       - kisak-fresh (default)
       - kisak-turtle

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -39,7 +39,7 @@ also assumes you have Steam Play  enabled for any game.
 
 Repeat the below steps on every combination of GPUs possible on your system.
 On hybrid systems, try in hybrid mode (both cards on and available) and
-dedicated GPU modes (single card on and available). 
+dedicated GPU modes (single card on and available).
 
 See the page on {ref}`using a dedicated GPU <howto::dedicated-gpu>` for tips on
 switching graphics cards.
@@ -67,9 +67,9 @@ switching graphics cards.
     - Can be played properly
 - Install a game. Ensure the installer UI is correct, the game is installed in
   the right place, and it can be played.
-- Switch to different gaming-graphics-core24 branches and ensure all of them
+- Switch to different gaming-graphics-core26 branches and ensure all of them
   work correctly. You can switch between branches using `sudo snap refresh
-  gaming-graphics-core24 --channel=<branch>/stable`. The three branches are
+  gaming-graphics-core26 --channel=<branch>/stable`. The three branches are
   `oibaf-latest`, `kisak-fresh` and `kisak-turtle`.
 - Plug in a supported controller (PS4, Xbox One and Xbox 360 controllers) and
   make sure the input is processed in the games.
@@ -148,13 +148,13 @@ ensure you use both a Proton and a Native game.
 Steam game collections can be a useful feature for keeping track of well-tested games. Follow these steps to create a *Dynamic Collection* that automatically populates with games based on Steam Deck status:
 
 1. Go to Steam's Library tab
-2. Click the four boxes to the right of Home 
-> ![Selecting your collections in Steam.](../assets/testing-four-boxes.png) 
+2. Click the four boxes to the right of Home
+> ![Selecting your collections in Steam.](../assets/testing-four-boxes.png)
 3. Click the empty box labeled "Create a new Collection"
 4. Give it a name, e.g. "Verified and Playable on Deck"
 5. Select *Create Dynamic Collection*; alternatively, select *Create Collection* to manually add games yourself
 6. Under Hardware Support, click the *Steam Deck* dropdown and select a verified status for the collection
-> ![Selecting verified status for collection in Steam.](../assets/testing-verified-status.png) 
+> ![Selecting verified status for collection in Steam.](../assets/testing-verified-status.png)
 7. Scroll down and you should see all the games in your library that meet the criteria you selected
 
 Repeat steps 1 and 2 to see past collections you've made or to create new collections.

--- a/docs/howto/change-mesa-graphics.md
+++ b/docs/howto/change-mesa-graphics.md
@@ -8,11 +8,11 @@ myst:
 (howto::change-mesa-graphics)=
 # Change the mesa/graphics version
 
-The Steam snap relies on the [gaming-graphics-core24 snap](https://github.com/canonical/gaming-graphics/) for
-graphics packages. You can verify this by running `snap connections steam`.  
+The Steam snap relies on the [gaming-graphics-core26 snap](https://github.com/canonical/gaming-graphics/) for
+graphics packages. You can verify this by running `snap connections steam`.
 
 You may switch
-[gaming-graphics-core24](https://github.com/canonical/gaming-graphics/) to a different channel to use
+[gaming-graphics-core26](https://github.com/canonical/gaming-graphics/) to a different channel to use
 different versions of mesa and other graphics libraries.
 
 Currently, the channels are:
@@ -23,11 +23,11 @@ Currently, the channels are:
 Switch between them with the following command:
 
 ```shell
-snap refresh gaming-graphics-core24 --channel <channel>
+snap refresh gaming-graphics-core26 --channel <channel>
 ```
 
-To find what version of the [gaming-graphics-core24](https://github.com/canonical/gaming-graphics/) Snap you have, use the following command:
+To find what version of the [gaming-graphics-core26](https://github.com/canonical/gaming-graphics/) Snap you have, use the following command:
 
 ```shell
-snap info gaming-graphics-core24
+snap info gaming-graphics-core26
 ```

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -11,7 +11,7 @@ Confinement
 GameMode
   A Linux daemon/library that optimizes system performance for gaming by adjusting CPU governor, I/O priority, and other settings when games are running.
 
-gaming-graphics-core24-snap
+gaming-graphics-core26-snap
   Graphics stack useful as a content snap for gaming snaps.
 
 MangoHud

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -403,6 +403,7 @@ parts:
       - libxcb-dri3-0:i386
       - xkb-data
       - libpci3
+      - libx11-data
       - libvulkan1:i386
       - libvulkan1:amd64
       - libxml2-16:i386

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
 adopt-info: steam
 grade: stable
 confinement: strict
-base: core24
+base: core26
 platforms:
   amd64:
 compression: lzo
@@ -84,10 +84,10 @@ layout:
     symlink: $SNAP/usr/lib/x86_64-linux-gnu/mangohud
 
 plugs:
-  gaming-graphics-core24:
+  gaming-graphics-core26:
     interface: content
     target: $SNAP/graphics
-    default-provider: gaming-graphics-core24
+    default-provider: gaming-graphics-core26
   gtk-3-themes:
     interface: content
     target: $SNAP/share/themes
@@ -250,10 +250,10 @@ parts:
     source: https://github.com/mesonbuild/meson.git
     source-tag: "1.8.3"
     override-build: |
-      python3 -m pip install . --break-system-packages
+      /usr/bin/python3 -m pip install . --break-system-packages
       mkdir -p $CRAFT_PART_INSTALL/usr/lib/python3/dist-packages
       rm -rf $CRAFT_PART_INSTALL/usr/lib/python3/dist-packages/meson*
-      python3 -m pip install --target=$CRAFT_PART_INSTALL/usr .
+      /usr/bin/python3 -m pip install --target=$CRAFT_PART_INSTALL/usr .
       mv $CRAFT_PART_INSTALL/usr/meson* $CRAFT_PART_INSTALL/usr/lib/python3/dist-packages/
       sed -i "s%^#!/usr/bin/python3$%#!/usr/bin/env python3%g" /usr/local/bin/meson
       sed -i "s%^#!/usr/bin/python3$%#!/usr/bin/env python3%g" $CRAFT_PART_INSTALL/usr/bin/meson
@@ -273,6 +273,7 @@ parts:
       - CC: gcc -m32
       - CXX: g++ -m32
       - PKG_CONFIG_PATH: /usr/lib/i386-linux-gnu/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig
+      - CXXFLAGS: -include sstream
     meson-parameters:
       - --prefix=/usr
       - --libdir=lib/i386-linux-gnu/mangohud
@@ -308,6 +309,8 @@ parts:
     plugin: meson
     organize:
       snap/steam/current/usr: usr
+    build-environment:
+      - CXXFLAGS: -include sstream
     meson-parameters:
       - --prefix=/usr
       - --libdir=lib/x86_64-linux-gnu/mangohud
@@ -335,6 +338,7 @@ parts:
       - --libdir=lib/i386-linux-gnu
     build-packages:
       - libsystemd-dev:i386
+      - systemd-dev
       - libdbus-1-dev:i386
       - pkg-config
     stage:
@@ -354,6 +358,7 @@ parts:
       - --libdir=lib/x86_64-linux-gnu
     build-packages:
       - libsystemd-dev
+      - systemd-dev
       - libdbus-1-dev
       - pkg-config
     stage:
@@ -387,7 +392,7 @@ parts:
       - dpkg-dev
       - dirmngr # Needed for launchpad builds
     build-snaps:
-      - core24
+      - core26
     stage-packages:
       - steam-launcher
       - steam-libs-amd64
@@ -399,10 +404,10 @@ parts:
       - libpci3
       - libvulkan1:i386
       - libvulkan1:amd64
-      - libxml2:i386
-      - libxml2:amd64
-      - libicu74:i386
-      - libicu74:amd64
+      - libxml2-16:i386
+      - libxml2-16:amd64
+      - libicu78:i386
+      - libicu78:amd64
       - zlib1g:i386
       - zlib1g:amd64
       - xdg-utils
@@ -415,8 +420,7 @@ parts:
       - locales-all
       - usbutils # Allows finding controllers etc
       - psmisc
-      - libfuse2:amd64
-      - libfuse2:i386
+      - libfuse2t64:amd64
       - libxss1:amd64
       - libxss1:i386
       - x11-xserver-utils
@@ -456,20 +460,23 @@ parts:
       - libsdl2-2.0-0:amd64
       - libaom3:i386
       - libaom3:amd64
-      - libavcodec60:i386
-      - libavcodec60:amd64
-      - libavutil58:i386
-      - libavutil58:amd64
+      - libavcodec62:i386
+      - libavcodec62:amd64
+      - libavutil60:i386
+      - libavutil60:amd64
       - libdav1d7:i386
       - libdav1d7:amd64
-      - libswscale7:i386
-      - libswscale7:amd64
-      - libvpx9:i386
-      - libvpx9:amd64
+      - libswscale9:i386
+      - libswscale9:amd64
+      - libvpx12:i386
+      - libvpx12:amd64
     override-build: |
       craftctl default
       # Set the snap version from the .deb package version
       craftctl set version=$(dpkg-parsechangelog -l $CRAFT_PART_INSTALL/usr/share/doc/steam-launcher/changelog.*.gz -S Version | sed -e s/1://g)
+    stage:
+      - -usr/bin/python3*
+      - -usr/lib/python3.*
     prime:
       - -usr/include
       - -usr/share/man
@@ -486,12 +493,12 @@ parts:
       - -usr/lib/*/libvulkan*
       - -usr/lib/*/libVk*
       - -usr/lib/*/libLLVM*
-      - -usr/lib/*/libgallium* # provided by gaming-graphics-core24
+      - -usr/lib/*/libgallium* # provided by gaming-graphics-core26
       - -usr/lib/*/libasound.so* # conflicts with alsa-mixin
     override-prime: |
       set -eux
       craftctl default
-      cp -a /snap/core24/current/usr/lib/i386-linux-gnu/* usr/lib/i386-linux-gnu/
+      cp -a /snap/core26/current/usr/lib/i386-linux-gnu/* usr/lib/i386-linux-gnu/
 
   yaru-skin:
     plugin: nil
@@ -526,12 +533,12 @@ parts:
     after: [steam, conditioning]
     plugin: nil
     build-snaps:
-      - gaming-graphics-core24/kisak-fresh/stable
+      - gaming-graphics-core26/kisak-fresh/candidate
     override-prime: |
       set -eux
-      cd /snap/gaming-graphics-core24/current/usr/lib
+      cd /snap/gaming-graphics-core26/current/usr/lib
       find . -type f,l -exec rm -f $CRAFT_PRIME/usr/lib/{} \;
-      cd /snap/gaming-graphics-core24/current/usr/share
+      cd /snap/gaming-graphics-core26/current/usr/share
       find . -type f,l -exec rm -f $CRAFT_PRIME/usr/share/{} \;
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,8 @@ layout:
   /usr/share/pipewire:
     bind: $SNAP/usr/share/pipewire
   /usr/share/X11/xkb:
-    bind: $SNAP/usr/share/X11/xkb
+    # $SNAP/usr/share/X11/xkb is a symlink
+    bind: $SNAP/usr/share/xkeyboard-config-2
   /usr/lib/x86_64-linux-gnu/libvulkan_intel.so:
     symlink: $SNAP/graphics/usr/lib/x86_64-linux-gnu/libvulkan_intel.so
   /usr/lib/i386-linux-gnu/libvulkan_intel.so:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -534,7 +534,7 @@ parts:
     after: [steam, conditioning]
     plugin: nil
     build-snaps:
-      - gaming-graphics-core26/kisak-fresh/candidate
+      - gaming-graphics-core26/kisak-fresh/stable
     override-prime: |
       set -eux
       cd /snap/gaming-graphics-core26/current/usr/lib

--- a/src/desktop-launch
+++ b/src/desktop-launch
@@ -6,10 +6,10 @@
 # shellcheck disable=SC2034
 START=$(date +%s.%N)
 
-if ! snapctl is-connected "gaming-graphics-core24"; then
+if ! snapctl is-connected "gaming-graphics-core26"; then
   echo "ERROR: not connected to the gaming-mesa content interface."
   echo "To connect:"
-  echo "sudo snap connect steam:gaming-graphics-core24 gaming-graphics-core24"
+  echo "sudo snap connect steam:gaming-graphics-core26 gaming-graphics-core26"
   exit 1
 fi
 


### PR DESCRIPTION
To test, use the `stable/core26` branch of Steam: `snap refresh steam --channel stable/core26`.

To revert to stable steam, use `snap refresh steam --stable`

Call for testing: https://github.com/canonical/steam-snap/discussions/538

---

UDENG-11351