### PR TITLE
docs: Update all remaining steam-snap/wiki refs to point to ubuntu.com/docs/steam/

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
     description: |
       Please search to see if an issue already exists for the bug you encountered: https://github.com/canonical/steam-snap/issues?q=label%3Atype%2Fbug.
 
-      Be sure to check the [wiki](https://github.com/canonical/steam-snap/wiki) to see if your issue is addressed.
+      Be sure to check the [docs](https://ubuntu.com/docs/steam/) to see if your issue is addressed.
 
       If you are able, it is helpful to test if the problem occurs on the deb version of Steam or not.
     options:
@@ -50,7 +50,7 @@ body:
   attributes:
     label: Environment
     description: |
-      Run `snap run steam.report` in a terminal or right-click Steam and choose "Report", then paste the output here. More info on this command [here](https://github.com/canonical/steam-snap/wiki/Troubleshooting#submitting-a-steam-report).
+      Run `snap run steam.report` in a terminal or right-click Steam and choose "Report", then paste the output here. More info on this command [here](https://ubuntu.com/docs/steam/contributing/reports/).
     placeholder: |
       os_release:
           name:
@@ -74,7 +74,7 @@ body:
   attributes:
     label: gaming-graphics-core24 version
     description: |
-      Please select the version(s) of the [gaming-graphics-core24](https://github.com/canonical/gaming-graphics/) Snap you have tried/this issue affects. More info on this [here](https://github.com/canonical/steam-snap/wiki/FAQ#how-do-i-use-a-different-mesagraphics-version).
+      Please select the version(s) of the [gaming-graphics-core24](https://github.com/canonical/gaming-graphics/) Snap you have tried/this issue affects. More info on this [here](https://ubuntu.com/docs/steam/howto/change-mesa-graphics/).
 
       If the issue is graphics/GPU related, it is very useful to us if you try each gaming-graphics-core24 branch and report observed behavior differences.
     options:
@@ -89,9 +89,9 @@ body:
     label: |
       Anything else?
     description: |
-      Screenshots? [Logs](https://github.com/canonical/steam-snap/wiki/Troubleshooting#view-logs)? Links? Anything that will give us more context about the issue. If pasting logs, please format them by surrounding the text with ```.
+      Screenshots? [Logs](https://ubuntu.com/docs/steam/howto/troubleshooting/#view-logs)? Links? Anything that will give us more context about the issue. If pasting logs, please format them by surrounding the text with ```.
 
-      Please include [Steam logs](https://github.com/canonical/steam-snap/wiki/Troubleshooting#view-logs) (if applicable) and any additional steps you took to troubleshoot. For troubleshooting ideas, see the [wiki](https://github.com/canonical/steam-snap/wiki).
+      Please include [Steam logs](https://ubuntu.com/docs/steam/howto/troubleshooting/#view-logs) (if applicable) and any additional steps you took to troubleshoot. For troubleshooting ideas, see the [docs](https://ubuntu.com/docs/steam/).
 
       If you are able, please include whether the issue occurs on the Steam deb as well as the Snap.
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -91,9 +91,9 @@ switching graphics cards.
   and alter Proton versions.
 - Go to Big Picture Mode. Ensure all text is properly displayed and you can
   navigate the UI.
-- Switch to non-English keyboard (ex. Russian). Ensure you can type non-English
-- [Ensure you can add a custom Proton version and use it.](https://github.com/canonical/steam-snap/wiki/FAQ#how-do-i-use-a-custom-proton-version)
-characters into the Steam client.
+- Switch to non-English keyboard (ex. Russian). Ensure you can type non-English characters into the Steam client.
+- {ref}`Ensure you can add a custom Proton version and use it. <howto::custom-proton>`
+
 - Test MangoHud
     - In the Snap shell, make sure MangoHud works with `mangohud glxgears`.
     - For *native* games, ensure adding `mangohud %command%` as launch options

--- a/docs/howto/configure-proton.md
+++ b/docs/howto/configure-proton.md
@@ -45,6 +45,7 @@ Right-click on the game title in your library, then navigate to {guilabel}`Prope
 
 Check "Force the use of a Specific Steam Play compatibility tool", and choose a Proton version.
 
+(howto::custom-proton)=
 ## Use a custom Proton version
 
 Run Steam at least once.

--- a/docs/howto/troubleshooting/index.md
+++ b/docs/howto/troubleshooting/index.md
@@ -32,7 +32,7 @@ You can still open an issue if one of these workarounds fixes a problem, but ple
 
 ## Troubleshooting specific games
 
-You may check the [reports][reports] discussions for troubleshooting tips with a specific game, and expected results. Also check {term}`ProtonDB` to see if your game *should* work based on other's input. If our [reports][reports] don't contain the game you're experiencing issues with, feel free to add it with the [steam.report tool][steamreport]. Some games may also be listed on the {ref}`known game workarounds page <howto::game-workarounds>`.
+You may check the [reports][reports] discussions for troubleshooting tips with a specific game, and expected results. Also check {term}`ProtonDB` to see if your game *should* work based on other's input. If our [reports][reports] don't contain the game you're experiencing issues with, feel free to add it with the {doc}`steam.report tool </contributing/reports>`. Some games may also be listed on the {doc}`known game workarounds page </howto/troubleshooting/game-workarounds>`.
 
 You can also check the [PC Gaming Wiki][10] for information on game compatibility, local and cloud game files, and system support.
 
@@ -178,5 +178,3 @@ Game workarounds <game-workarounds>
 [10]: https://www.pcgamingwiki.com/wiki
 [issues]: https://github.com/canonical/steam-snap/issues
 [reports]: https://github.com/canonical/steam-snap/discussions/categories/game-reports
-[steamreport]: https://github.com/canonical/steam-snap/wiki/Troubleshooting#submitting-a-steam-report
-[workarounds]: https://github.com/canonical/steam-snap/wiki/Known-Workarounds

--- a/src/nvidia32
+++ b/src/nvidia32
@@ -10,7 +10,7 @@ TITLE = "NVIDIA 32-bit Not Found"
 TEXT = """<b>32-bit NVIDIA driver files were not found on your host system.</b>
 It is recommended that you install them for the best experience.
 
-See <a href="https://github.com/canonical/steam-snap/wiki/FAQ#32-bit-driver">https://github.com/canonical/steam-snap/wiki/FAQ#32-bit-driver</a> for more information."""
+See <a href="https://ubuntu.com/docs/steam/howto/dedicated-gpu/#bit-driver">https://ubuntu.com/docs/steam/howto/dedicated-gpu/#bit-driver</a> for more information."""
 COMMAND = """sudo dpkg --add-architecture i386
 sudo apt update
 sudo apt install libnvidia-gl-{}:i386"""

--- a/src/steamreport
+++ b/src/steamreport
@@ -12,7 +12,7 @@ from gi.repository import Gtk, Gdk
 
 ISSUE_URL = "https://github.com/canonical/steam-snap/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml"
 DISCUSSION_URL = "https://github.com/canonical/steam-snap/discussions/new?category=game-reports"
-WIKI_URL = "https://github.com/canonical/steam-snap/wiki/Troubleshooting#submitting-a-steam-report"
+WIKI_URL = "https://ubuntu.com/docs/steam/contributing/reports/"
 GRAPHQL_URL = "https://api.github.com/graphql"
 TOKEN_URL = "https://github.com/settings/tokens/new"
 


### PR DESCRIPTION
Testing:

- docs/make run is green 
- links on http://127.0.0.1:8000/howto/troubleshooting/ and http://127.0.0.1:8000/contributing/development/  navigate correctly

The links on troubleshooting/ now point to whole pages via the {doc} markup,

e.g.

On https://ubuntu.com/docs/steam/howto/troubleshooting/ it says:
"Some games may also be listed on the <a href="...">known game workarounds page</a>."

Before :
href="https://ubuntu.com/docs/steam/howto/troubleshooting/game-workarounds/#howto-game-workarounds"
After:
href="https://ubuntu.com/docs/steam/howto/troubleshooting/game-workarounds/"

Fixes #533